### PR TITLE
Voice latency streaming overhaul — live STT, WS TTS, speculative RAG

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,7 +31,14 @@
       "expo-secure-store",
       "expo-asset",
       "./plugins/withUnityFramework",
-      "expo-font"
+      "expo-font",
+      [
+        "expo-speech-recognition",
+        {
+          "microphonePermission": "Allow $(PRODUCT_NAME) to use the microphone so you can talk to Aria.",
+          "speechRecognitionPermission": "Allow $(PRODUCT_NAME) to use speech recognition so Aria can understand you faster."
+        }
+      ]
     ]
   }
 }

--- a/docs/voice-latency-streaming.md
+++ b/docs/voice-latency-streaming.md
@@ -1,0 +1,96 @@
+# Voice Latency Streaming Overhaul
+
+> STATUS: Live on device (2026-07-18, branch `feat/voice-latency-streaming`, commits `3a433ef..cf50136` + Unity submodule `480e68f`, `472e2d6`). Measured on-device: 2.7–4.5s to first audio on the Unity avatar's legacy-TTS path (was 7.6s cold / est. 5s+ per turn pre-overhaul), STT finalization 37–181ms (was 700–1500ms). Open items at the bottom.
+
+## Problem
+
+The gap between the user finishing speaking and the avatar starting to answer was the app's biggest UX problem: ~2.2–5.5s, all of it a strictly sequential chain — expo-av recording teardown → Whisper file upload → a hardcoded 750ms client throttle → embedding round trip → Supabase vector search → gpt-4o time-to-first-token → wait for a full first sentence → whole-sentence blocking TTS → WebView MP3 decode. The May 2026 concurrent play loop only overlapped sentences 2..N; first audio never overlapped anything.
+
+Target: ~0.8–1.5s to first audio by streaming every stage, with the constraint that the curated NZ RAG corpus, the v2-nz-safety prompt, and the timestamp-driven viseme lip sync stay exactly as they are.
+
+## Architecture
+
+Every stage streams, and every stage falls back independently to the previous blocking behaviour — worst case equals the old pipeline.
+
+```
+user talks ──► expo-speech-recognition partials (en-NZ, continuous)
+                 │  onPartial → speculative RAG (fires on 600ms-stable partial)
+tap-stop ─────► session.stop() → final transcript in ~40–180ms
+                 ├─ speculativeRag.resolve(final) → chunks reused on lexical match
+                 ├─ ElevenLabs WS opened in parallel (hides in LLM TTFT)     [streaming mode]
+                 └─ chatStream(skipThrottle, preRetrievedChunks)
+LLM tokens ────► marker-stripped → sentence splitter (shared module)
+                 ├─ [streaming] tokens → WS immediately; flush() at boundaries;
+                 │   per-chunk alignment → viseme frames → WebView PCM scheduling
+                 └─ [legacy]    per-sentence REST tts() → ordered play queue
+```
+
+### Mode selection (per turn)
+
+`streaming` iff ALL of: `voiceConfig.VOICE_STREAMING_TTS` && user setting `fastVoiceMode` && ElevenLabs key present && **no Azure creds** (Azure keeps its higher-fidelity phoneme-viseme REST path) && renderer exposes `supportsStreamingAudio` (AvatarVRM yes; **UnityAvatarBridge deliberately not** — the Unity renderer always runs the legacy per-sentence path) && no sticky `ttsDegraded` from an earlier WS failure this session.
+
+## Components
+
+| Stage | Files | What changed |
+|---|---|---|
+| Streaming STT | `src/lib/stt/sttService.js`, `expoSpeechRecognition.js`, `whisperFallback.js` | expo-speech-recognition (SDK-54 pin **3.1.3** — v56.x needs iOS 16.4 and gets silently skipped by autolinking) streams partials while the user talks; `recordingOptions.persist` keeps audio so an empty live transcript is rescued through Whisper; sticky `sttDegraded` falls back wholesale after a start failure. Single mic owner per turn (no parallel expo-av recording — AVAudioSession contention). |
+| Hands-free (opt-in) | same + `SettingsContext.handsFreeMode` | Own endpointing: ≥1 partial, then 1.2s of no-partial-change + volume < 0 → auto-stop; 8s lead-silence gives up; re-arms after each completed response; mic stays off while the avatar speaks (echo). |
+| Speculative RAG | `src/lib/rag/speculativeRetrieval.js` | Fires `search()` when a partial (≥4 words) is stable 600ms mid-listening (900→600ms after device testing; quick taps leave no gap). Max 2 fires/turn. Reuse gate: token Jaccard ≥ 0.8 or token-prefix with ≤25% char growth. `chatStream({ preRetrievedChunks })` skips the hot-path search; prompt/citation construction is byte-identical (telemetry path `voice-speculative`). |
+| Hot-path cleanup | `src/lib/openaiService.js`, `src/lib/net/withTimeout.js`, `src/lib/voice/prewarm.js` | `skipThrottle` for voice turns (750ms `_throttle` kept for text chat). Timeouts everywhere: embed 5s / Supabase RPC 4s (→ **degrade to zero chunks and answer anyway** — v2 prompt handles no-passage turns), Whisper 15s, LLM XHR 60s + 12s TTFB watchdog, ElevenLabs REST 10s. Pre-warm on VoiceScreen mount + `startRecording()` (5min debounce): SecureStore key reads + one tiny authed request per host (openai/supabase/elevenlabs) to warm TLS pools. |
+| Streaming TTS | `src/lib/tts/elevenLabsStreamService.js`, `ttsMode.js` | One WS session per turn: `stream-input`, `eleven_flash_v2_5`, `pcm_22050`, `chunk_length_schedule [90,120,160,250]`, auto_mode off. `open()` fires alongside the LLM request. Tokens forwarded word-buffered with word-level `normalizeSpokenText` (equivalent to the REST path's pass — all its patterns are word-bounded). `flush()` at sentence boundaries deliberately does NOT push the held word (it belongs to the next sentence). Per-chunk `alignment` → `streamingVisemeAccumulator`. Watchdogs: open 3s, audio-stall 6s → `onError` once → sticky `markTtsDegraded()` + unspoken sentences replayed through the REST cascade from the last-shown subtitle. |
+| Streaming visemes | `src/lib/lipsync/streamingVisemeAccumulator.js`, `createVisemeTimeline.js` (`streaming` option) | Per-chunk alignment → absolute-stream-time frames; runtime detection of chunk- vs stream-relative timestamps; trailing partial words carried across chunks so G2P sees whole words; `streaming: true` skips `applyFinalLowering` (would droop the mouth mid-sentence). Returns per-char absolute times — the subtitle-timing join key. |
+| WebView playback | `src/features/avatar/components/AvatarVRM.js` | New in-page API `startStreamingPlayback / appendAudioChunk / endStreamingPlayback / setSpeechEmotion`: base64 PCM → Int16 → Float32 AudioBuffers scheduled gaplessly (`nextStartTime`); first chunk keeps the 10ms anchor semantics; underruns restart +20ms and shift the anchor so visemes stay aligned (count reported in `audioEnd`). `_stopCurrent` cancels scheduled sources (barge-in). Eager AudioContext at boot. RN ref exposes the same + `supportsStreamingAudio: true`. Fixed pre-existing leak: `stopAudio()` now resolves the in-flight play promise. |
+| Hook orchestration | `src/features/voice/hooks/useAvatarConversation.js`, `sentenceTracker.js` | `createSentenceSplitter` extracted (identical `.!?` + early-comma-at->150-chars logic, parity-tested); producer routes sentences to WS-flush + subtitle records (streaming) or the TTS queue (legacy/fallback — the queue is also the failure-replay target). Subtitles/emotion synced to *playback* via charTimes→wallclock timers, not synthesis. Barge-in aborts WS + STT + speculative + playback. |
+| Settings | `src/context/SettingsContext.tsx`, `ProfileScreen.js` | `fastVoiceMode` (default **true** — user kill switch, "Faster Voice Responses"), `handsFreeMode` (default false). `speechRate` default 0.78 → **0.9** with hydration migration (a stored 0.78 is the old default — it was never a selectable option — so it's dropped in favour of the new default). |
+| Config | `src/lib/voice/voiceConfig.js` | Single source of truth (ragConfig pattern) for every flag/threshold named above. Flip `ELEVEN_STREAM_MODEL` to `eleven_turbo_v2_5` for the quality A/B. |
+
+## Latency instrumentation
+
+Existing `[LATENCY]` format kept; new checkpoints: `stt_partial_first_ms`, `stt_final_ms` (+`source=live|whisper|whisper-rescue`), `rag_speculative=hit|miss|none`, `ws_open_ms`, `tts_first_chunk_ms`. `[LATENCY SUMMARY]` gains `mode: streaming|streaming-degraded|legacy`. `scripts/parse-latency.mjs` still parses the summary lines.
+
+## Measured results (Richman's iPhone, Wi-Fi, 2026-07-18, Unity avatar → legacy TTS mode)
+
+| Turn | to_first_audio | stt_final | rag | llm_to_token | tts_first | Notes |
+|---|---|---|---|---|---|---|
+| 1 (cold) | 7599ms | 56ms | 3458ms | 1667ms | 1871ms | first-of-session: cold embed cache, cold Supabase, cold ElevenLabs |
+| 2 | 3983ms | 48ms | 1853ms | 1097ms | 728ms | |
+| 3 | 2719ms | 37ms | 1580ms | 703ms | 311ms | warm floor on this network |
+| later | 4447ms | 181ms | 2819ms | 683ms | 411ms | RAG variance dominates |
+
+Pre-overhaul, the same turns would have added ~0.7–1.5s Whisper upload + up to 750ms throttle on top of the same RAG/LLM costs. STT itself improved 700–1500ms → 37–181ms.
+
+**Where the remaining time goes:** RAG (1.5–3.5s from the phone — two sequential round trips, embedding then `match_chunks`, over a mobile radio whose pooled connections idle out between turns) and LLM TTFT (~0.7–1.7s). Speculative RAG removes the former when it fires; hands-free mode guarantees the firing window (its 1.2s silence wait ⊇ the 600ms stabilization window).
+
+## Device issues found & fixed during rollout (all committed)
+
+1. **`expo-speech-recognition` version trap** — `latest` (56.0.1) targets Expo SDK 56 / iOS 16.4; CocoaPods autolinking *silently* skips pods whose platform requirement exceeds the app target (15.1), leaving `Cannot find native module`. The npm dist-tag `sdk-54` → **3.1.3**. (`f1c667b`)
+2. **Simulator builds are impossible with UaaL** — vendored `UnityFramework` is a device-only arm64 dylib; `expo run:ios` against a simulator fails at link. Physical device only. The JS-side `requireNativeModule('UnityAvatarModule')` also ran at import time and killed app boot wherever the module was missing — now guarded (warns + disables Unity avatar). (`86fc0ac`)
+3. **Recognition died instantly with "Audio session was interrupted"** — the WebView's AudioContext held the AVAudioSession. Fix: recognition starts with `iosCategory: playAndRecord + defaultToSpeaker/allowBluetooth + measurement`. (`86fc0ac`)
+4. **Every reply then played quiet** — playAndRecord/measurement outlives the recognition session, and expo-av's `setAudioModeAsync` resets only the *category*, not the session *mode*; `measurement` mode strangles speaker loudness. Fix: explicit `setCategoryIOS(playback/default)` + expo-av re-sync on stop/cancel/settle. User-confirmed. (`ca0e802`, `cf50136`)
+5. **Intermittent empty live transcripts → 1.4–2.4s whisper-rescue turns** — speech that starts before the recognizer's audio tap opens is lost. Fix: `startLiveSession` waits (≤1.5s) for `start`/`audiostart` before the UI shows "listening". Verified back to `source=live` at 181ms. (`cf50136`)
+6. **Wrong voices** — the old ElevenLabs voice-ID regex fallback made *every* avatar speak as Brian; the first fix then gave the male CC4 Aaron a female voice by name-matching "cc4_aria". Profiles now carry explicit `elevenVoiceId`/`openaiVoice` per character: Aria profiles → Bella/nova, Eric + Aaron → Brian/onyx (+ Aaron's Azure voice → en-US-EricNeural). (`3a433ef`, `6500a5c`)
+
+## Unity avatar (CC4 Aaron) notes
+
+- The Unity renderer keeps the **legacy per-sentence TTS path by design** (`supportsStreamingAudio` is only implemented in the WebView renderer). Streaming for Unity is future work (would need chunked audio through the native bridge).
+- **Camera framing** (submodule `472e2d6`): `render_focus_` moved 0.60→0.42m, y 1.595→1.628, pitch 6°→1.5° — head-and-shoulders portrait with ~13% clear headroom so the Dynamic Island no longer overlaps the avatar. Framing was iterated with phone-aspect renders straight from the Editor (RenderTexture via MCP `execute_code`) before rebuilding.
+- **UnityLibrary refresh workflow** (submodule `480e68f` added `Assets/Scripts/Editor/UaalExportBuild.cs`):
+  1. Editor menu `Tools → UaaL → Export iOS (uaal-export)` — or headless via MCP: `EditorApplication.delayCall += UaalExportBuild.Run;` then poll `uaal-export/export_result.json`.
+  2. `cd uaal-export && xcodebuild -project Unity-iPhone.xcodeproj -scheme UnityFramework -configuration Release -sdk iphoneos -destination generic/platform=iOS -derivedDataPath build_dd build`
+  3. `ditto uaal-export/Data UnityLibrary/Data && ditto uaal-export/build_dd/Build/Products/Release-iphoneos/UnityFramework.framework UnityLibrary/UnityFramework.framework`
+  4. `npx expo prebuild` (plugin copies into `ios/UnityLibrary`) → `npx expo run:ios --device <udid>`.
+  The stale-avatar bug this session (old beard/mouth behaviour on device) was exactly a missed step 3: a fresh Jul-14 build sat in `build_dd` while `UnityLibrary` still held Jul-12.
+
+## Verification
+
+- 111 jest tests (12 suites) incl. new: splitter parity vs the original inline producer, accumulator (both alignment reference frames, word carry-over, flush), speculative hit/miss/cap/cancel table, `createVisemeTimeline` streaming vs one-shot, stream service (BOS/word buffering/flush semantics/normalization/watchdogs/abort) — `npx jest`.
+- Safety: prompt path untouched (`buildSystemPrompt`/`buildUserContent`/citations byte-identical; chunks arrive via the same shape from the speculative path). `npm run rag:eval:safety` unaffected.
+- Fallback drills still owed on device: airplane-mode mid-stream (expect REST replay), invalid ElevenLabs key (cascade), mic permission denied (Whisper path), barge-in at each stage.
+
+## Open items / next levers
+
+1. **Single-round-trip retrieval**: a Supabase Edge Function doing embed + `match_chunks` server-side would collapse the phone's two sequential round trips — the dominant remaining cost (1.5–3.5s → likely well under 1s). Biggest and cheapest remaining win for the legacy path.
+2. **Streaming-mode field test**: `mode:"streaming"` (WS TTS + PCM playback + sub-sentence first audio) has not yet been exercised on device — requires a Three.js avatar (Classic/New Look/Eric). Verify lip-sync quality (debug overlay), underrun counts, and flash_v2_5 pronunciation of NZ helplines before defaulting anything further.
+3. **Hands-free field test**: endpointing thresholds (1.2s silence, volume < 0) are un-tuned against real elderly/hesitant speech; also the natural path to speculative-RAG hits.
+4. **flash vs turbo A/B** on NZ health content (`ELEVEN_STREAM_MODEL`).
+5. Deprecation cleanup: expo-av is deprecated in SDK 54 (warning at boot) — Unity-path playback and the Whisper fallback recorder should migrate to `expo-audio` eventually.

--- a/modules/unity-avatar-module/src/index.js
+++ b/modules/unity-avatar-module/src/index.js
@@ -11,6 +11,36 @@ import { requireNativeModule, requireNativeViewManager } from 'expo-modules-core
  *   — `visemes` drives Unity's co-articulation engine; `blendshapes` is the
  *   legacy fallback for payloads without viseme events.
  */
-export const NativeUnityAvatarModule = requireNativeModule('UnityAvatarModule');
+// UnityFramework is a device-only arm64 binary, so the native module doesn't
+// exist in simulator builds — and requireNativeModule throws at IMPORT time,
+// which would kill app boot for everyone (this file is in the static import
+// graph via AvatarUnity). Guard the lookup: on simulator the app runs
+// normally with the Three.js avatars, and the Unity profile no-ops loudly.
+function resolveNativeModule() {
+  try {
+    return requireNativeModule('UnityAvatarModule');
+  } catch (e) {
+    console.warn(
+      `[UnityAvatarModule] native module unavailable (${e.message}) — Unity avatar disabled (simulator build?)`
+    );
+    const warnOnce = () => console.warn('[UnityAvatarModule] call ignored — native module unavailable');
+    return {
+      initialize: async () => warnOnce(),
+      playAudio: async () => warnOnce(),
+      stopAudio: async () => {},
+      setDebugMode: async () => {},
+    };
+  }
+}
 
-export const UnityAvatarNativeView = requireNativeViewManager('UnityAvatarModule');
+function resolveNativeView() {
+  try {
+    return requireNativeViewManager('UnityAvatarModule');
+  } catch (e) {
+    return () => null; // renders nothing if the Unity profile is selected anyway
+  }
+}
+
+export const NativeUnityAvatarModule = resolveNativeModule();
+
+export const UnityAvatarNativeView = resolveNativeView();

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "expo-linear-gradient": "~15.0.8",
         "expo-secure-store": "~15.0.8",
         "expo-speech": "~14.0.8",
-        "expo-speech-recognition": "^56.0.1",
+        "expo-speech-recognition": "^3.1.3",
         "expo-status-bar": "~3.0.9",
         "microsoft-cognitiveservices-speech-sdk": "^1.50.0",
         "react": "19.1.0",
@@ -9604,9 +9604,9 @@
       }
     },
     "node_modules/expo-speech-recognition": {
-      "version": "56.0.1",
-      "resolved": "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-56.0.1.tgz",
-      "integrity": "sha512-TpP1KCiq3vYfSQF0XpUkWLXp4mTw6MLuyMGPzVVKwqzs7oiKlJ/e0q3PNNjfqs058X47ftqT+31lTaWRWRbmPg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-3.1.3.tgz",
+      "integrity": "sha512-vluXqggfY2AJcazYITvnV6YSE2rVe5SId5TpdjMC/m6JPUgHCOODrcHJtAQF6OUYl4f2T7oZSceGw6fJCC86Xw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "expo-linear-gradient": "~15.0.8",
         "expo-secure-store": "~15.0.8",
         "expo-speech": "~14.0.8",
+        "expo-speech-recognition": "^56.0.1",
         "expo-status-bar": "~3.0.9",
         "microsoft-cognitiveservices-speech-sdk": "^1.50.0",
         "react": "19.1.0",
@@ -9600,6 +9601,17 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-speech-recognition": {
+      "version": "56.0.1",
+      "resolved": "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-56.0.1.tgz",
+      "integrity": "sha512-TpP1KCiq3vYfSQF0XpUkWLXp4mTw6MLuyMGPzVVKwqzs7oiKlJ/e0q3PNNjfqs058X47ftqT+31lTaWRWRbmPg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "expo-linear-gradient": "~15.0.8",
     "expo-secure-store": "~15.0.8",
     "expo-speech": "~14.0.8",
-    "expo-speech-recognition": "^56.0.1",
+    "expo-speech-recognition": "^3.1.3",
     "expo-status-bar": "~3.0.9",
     "microsoft-cognitiveservices-speech-sdk": "^1.50.0",
     "react": "19.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "expo-linear-gradient": "~15.0.8",
     "expo-secure-store": "~15.0.8",
     "expo-speech": "~14.0.8",
+    "expo-speech-recognition": "^56.0.1",
     "expo-status-bar": "~3.0.9",
     "microsoft-cognitiveservices-speech-sdk": "^1.50.0",
     "react": "19.1.0",

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -86,7 +86,7 @@ const DEFAULTS: Settings = {
   responseStyle: 'balanced',
   jargonMode: 'explain',
   communicationMode: 'both',
-  speechRate: 0.78,
+  speechRate: 0.9,
 
   selectedAvatarId: 'aria_sdk',
 
@@ -126,6 +126,10 @@ export const SettingsProvider = ({ children }: { children: React.ReactNode }) =>
       .then((raw) => {
         if (raw) {
           const saved = JSON.parse(raw) as Partial<Settings>;
+          // Migration: 0.78 was the old hardcoded default and was never a
+          // selectable option (UI offers 0.82/1.0/1.15), so a stored 0.78 is
+          // the stale default, not a user choice — let the new default apply.
+          if (saved.speechRate === 0.78) delete saved.speechRate;
           setSettings((prev) => ({ ...prev, ...saved }));
         }
       })

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -60,6 +60,12 @@ export interface Settings {
 
   // Accessibility
   reducedMotion: boolean;
+
+  // Voice pipeline
+  /** Hands-free conversation: auto-detect end of speech instead of tap-to-stop. */
+  handsFreeMode: boolean;
+  /** Streaming voice pipeline (faster responses); off = classic per-sentence path. */
+  fastVoiceMode: boolean;
 }
 
 const DEFAULTS: Settings = {
@@ -87,6 +93,9 @@ const DEFAULTS: Settings = {
   supportLevel: 'comfortable',
 
   reducedMotion: false,
+
+  handsFreeMode: false,
+  fastVoiceMode: true,
 };
 
 export interface SettingsContextValue extends Settings {
@@ -230,6 +239,9 @@ export const SettingsProvider = ({ children }: { children: React.ReactNode }) =>
     supportLevel: settings.supportLevel,
 
     reducedMotion: settings.reducedMotion,
+
+    handsFreeMode: settings.handsFreeMode,
+    fastVoiceMode: settings.fastVoiceMode,
 
     colors,
     setTextSize,

--- a/src/features/avatar/components/AvatarVRM.js
+++ b/src/features/avatar/components/AvatarVRM.js
@@ -1881,13 +1881,10 @@ const LipSyncController = {
   },
 };
 
-// ─── Helper: decode a data URI and play it through AudioContext ───────────────
-async function _decodeAndPlay(dataUri) {
-  const base64 = dataUri.slice(dataUri.indexOf(',') + 1);
-  const bin    = atob(base64);
-  const ab     = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) ab[i] = bin.charCodeAt(i);
-
+// ─── AudioContext lifecycle ───────────────────────────────────────────────────
+// Created eagerly at boot (see call below) so the first playback doesn't pay
+// context spin-up; falls back to lazy creation if the boot call ever fails.
+function _ensureAudioCtx() {
   if (!lipSyncCtx) {
     lipSyncCtx = new (window.AudioContext || window.webkitAudioContext)();
     // Auto-resume if iOS suspends the context mid-playback (e.g. audio session change)
@@ -1897,6 +1894,18 @@ async function _decodeAndPlay(dataUri) {
       }
     });
   }
+  return lipSyncCtx;
+}
+try { _ensureAudioCtx().resume().catch(function() {}); } catch (e) {}
+
+// ─── Helper: decode a data URI and play it through AudioContext ───────────────
+async function _decodeAndPlay(dataUri) {
+  const base64 = dataUri.slice(dataUri.indexOf(',') + 1);
+  const bin    = atob(base64);
+  const ab     = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) ab[i] = bin.charCodeAt(i);
+
+  _ensureAudioCtx();
   if (lipSyncCtx.state === 'suspended') await lipSyncCtx.resume();
 
   return lipSyncCtx.decodeAudioData(ab.buffer);
@@ -1908,6 +1917,8 @@ function _stopCurrent() {
     try { lipSyncSource.stop(); } catch(e) {}
     lipSyncSource = null;
   }
+  // Also cancel any active streaming session (defined below; hoisted at call time).
+  if (typeof _stopStreaming === 'function') _stopStreaming();
   lipSyncActive   = false;
   lipSyncAnalyser = null;
   lipSyncBuf      = null;
@@ -1991,8 +2002,149 @@ window.playAudioWithVisemeTimeline = async function(dataUri, timeline, emotion) 
   }
 };
 
+// ─── STREAMING PLAYBACK PATH ─────────────────────────────────────────────────
+// Gapless PCM chunk scheduling for the ElevenLabs WebSocket pipeline. Audio
+// arrives as base64 16-bit mono PCM chunks with viseme frames already in
+// absolute stream time; each chunk becomes an AudioBuffer scheduled at
+// nextStartTime so playback is seamless. The existing LipSyncController works
+// unchanged: frames are appended in order and its clock
+// (ctx.currentTime - audioStartTime) IS the stream position.
+let streamSession = null; // { id, sampleRate, nextStartTime, sources, pending, endRequested, underruns, started }
+
+function _stopStreaming() {
+  if (!streamSession) return;
+  for (const src of streamSession.sources) {
+    src.onended = null;
+    try { src.stop(); } catch(e) {}
+  }
+  streamSession = null;
+}
+
+window.startStreamingPlayback = function(sessionId, sampleRate, emotion) {
+  _stopCurrent();
+  visemeMode     = true;
+  visemeTimeline = { frames: [], totalDuration: 0 };
+  speechEmotion  = emotion || 'neutral';
+  lipSyncActive  = true;
+  streamSession = {
+    id: sessionId,
+    sampleRate: sampleRate || 22050,
+    nextStartTime: 0,
+    sources: [],
+    pending: 0,        // scheduled sources that haven't ended yet
+    endRequested: false,
+    underruns: 0,
+    started: false,
+  };
+};
+
+window.appendAudioChunk = function(sessionId, base64Pcm, visemeFrames) {
+  const s = streamSession;
+  if (!s || s.id !== sessionId) return; // stale chunk after stop/new session
+  try {
+    // Frames may arrive without audio (e.g. the flushed trailing word whose
+    // sound was in an earlier chunk) — append them and skip scheduling.
+    if (!base64Pcm) {
+      if (visemeFrames && visemeFrames.length && visemeTimeline) {
+        Array.prototype.push.apply(visemeTimeline.frames, visemeFrames);
+        const last = visemeFrames[visemeFrames.length - 1];
+        visemeTimeline.totalDuration = Math.max(visemeTimeline.totalDuration, last.time + last.duration);
+      }
+      return;
+    }
+
+    _ensureAudioCtx();
+    if (lipSyncCtx.state === 'suspended') lipSyncCtx.resume().catch(function() {});
+
+    // base64 → Int16 PCM → Float32 AudioBuffer
+    const bin = atob(base64Pcm);
+    const n   = bin.length >> 1;
+    if (n === 0) return;
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    const pcm = new Int16Array(bytes.buffer, 0, n);
+    const buffer = lipSyncCtx.createBuffer(1, n, s.sampleRate);
+    const ch = buffer.getChannelData(0);
+    for (let i = 0; i < n; i++) ch[i] = pcm[i] / 32768;
+
+    if (!s.started) {
+      // First chunk anchors the stream clock — same 10ms look-ahead semantics
+      // as the one-shot path.
+      audioStartTime  = lipSyncCtx.currentTime + 0.010;
+      s.nextStartTime = audioStartTime;
+      s.started = true;
+      if (window.ReactNativeWebView) {
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'audioStart' }));
+      }
+    } else if (s.nextStartTime < lipSyncCtx.currentTime) {
+      // Underrun (network stall): restart slightly ahead and shift the viseme
+      // clock anchor by the gap so frames stay aligned with the audio.
+      const newStart = lipSyncCtx.currentTime + 0.02;
+      const shift    = newStart - s.nextStartTime;
+      audioStartTime += shift;
+      s.nextStartTime = newStart;
+      s.underruns++;
+    }
+
+    const src = lipSyncCtx.createBufferSource();
+    src.buffer = buffer;
+    src.connect(lipSyncCtx.destination);
+    src.onended = function() {
+      s.pending--;
+      const idx = s.sources.indexOf(src);
+      if (idx >= 0) s.sources.splice(idx, 1);
+      if (s.endRequested && s.pending === 0 && streamSession === s) {
+        const underruns = s.underruns;
+        streamSession = null;
+        _stopCurrent();
+        if (window.ReactNativeWebView) {
+          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'audioEnd', underruns: underruns }));
+        }
+      }
+    };
+    src.start(s.nextStartTime);
+    s.nextStartTime += buffer.duration;
+    s.sources.push(src);
+    s.pending++;
+
+    if (visemeFrames && visemeFrames.length && visemeTimeline) {
+      Array.prototype.push.apply(visemeTimeline.frames, visemeFrames);
+      const last = visemeFrames[visemeFrames.length - 1];
+      visemeTimeline.totalDuration = Math.max(visemeTimeline.totalDuration, last.time + last.duration);
+    }
+  } catch(err) {
+    _stopStreaming();
+    _onAudioEnded(String(err));
+  }
+};
+
+window.endStreamingPlayback = function(sessionId) {
+  const s = streamSession;
+  if (!s || s.id !== sessionId) return;
+  s.endRequested = true;
+  if (s.pending === 0) {
+    // Nothing scheduled (empty stream) or everything already finished.
+    const underruns = s.underruns;
+    const started = s.started;
+    streamSession = null;
+    _stopCurrent();
+    if (window.ReactNativeWebView) {
+      if (!started) {
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'audioStart' }));
+      }
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'audioEnd', underruns: underruns }));
+    }
+  }
+};
+
+// Per-sentence emotion updates during a stream (subtitle-synced from RN).
+window.setSpeechEmotion = function(emotion) {
+  speechEmotion = emotion || 'neutral';
+};
+
 // ─── STOP ────────────────────────────────────────────────────────────────────
 window.stopAudioLipSync = function() {
+  _stopStreaming();
   _stopCurrent();
 };
 
@@ -2066,11 +2218,45 @@ export const AvatarVRM = forwardRef(({
       }
     }),
     stopAudio: () => {
+      // Resolve any in-flight playAudio/endStreamingPlayback promise so the
+      // caller's await doesn't dangle forever after a barge-in.
+      const resolve = audioEndResolveRef.current;
       audioEndResolveRef.current = null;
       audioStartCbRef.current = null;
       webRef.current?.injectJavaScript(`window.stopAudioLipSync();true;`);
+      resolve?.();
     },
     setOnAudioStart: (cb) => { audioStartCbRef.current = cb; },
+
+    // ── Streaming playback (ElevenLabs WebSocket pipeline) ──────────────────
+    // Feature-detected by the hook via this flag; UnityAvatarBridge leaves it
+    // undefined so Unity profiles keep the whole-segment path.
+    supportsStreamingAudio: true,
+    /** Begin a streaming session. Chunks follow via appendAudioChunk. */
+    startStreamingPlayback: (sessionId, sampleRate, emotion) => {
+      webRef.current?.injectJavaScript(
+        `window.startStreamingPlayback(${JSON.stringify(sessionId)}, ${JSON.stringify(sampleRate)}, ${JSON.stringify(emotion || 'neutral')});true;`
+      );
+    },
+    /** Append a PCM chunk (base64) + viseme frames in absolute stream time. */
+    appendAudioChunk: (sessionId, base64Pcm, visemeFrames) => {
+      webRef.current?.injectJavaScript(
+        `window.appendAudioChunk(${JSON.stringify(sessionId)}, ${JSON.stringify(base64Pcm)}, ${JSON.stringify(visemeFrames ?? [])});true;`
+      );
+    },
+    /** No more chunks: resolves when the last scheduled chunk finishes. */
+    endStreamingPlayback: (sessionId) => new Promise(resolve => {
+      audioEndResolveRef.current = resolve;
+      webRef.current?.injectJavaScript(
+        `window.endStreamingPlayback(${JSON.stringify(sessionId)});true;`
+      );
+    }),
+    /** Update the speaking emotion mid-stream (per-sentence, subtitle-synced). */
+    setSpeechEmotion: (emotion) => {
+      webRef.current?.injectJavaScript(
+        `window.setSpeechEmotion(${JSON.stringify(emotion || 'neutral')});true;`
+      );
+    },
     /**
      * Toggle the developer viseme overlay inside the WebView.
      * Shows current active viseme, per-channel weights, and audio timing.

--- a/src/features/avatar/config/avatarProfiles.ts
+++ b/src/features/avatar/config/avatarProfiles.ts
@@ -39,6 +39,13 @@ export interface AvatarProfile {
   /** Static require() key resolved in VoiceScreen; absent for Unity renderers. */
   modelKey?: string;
   voice: string;
+  /**
+   * Provider-specific voices. `voice` above is the Azure voice name; ElevenLabs
+   * and OpenAI reject Azure names, so without these fields ttsService falls
+   * back to its hardcoded defaults and every avatar speaks with the same voice.
+   */
+  elevenVoiceId?: string;
+  openaiVoice?: string;
   /** Per-viseme peak weights, or null to use the renderer's built-in default. */
   visemeWeights: Record<string, number> | null;
 }
@@ -52,6 +59,8 @@ export const AVATAR_PROFILES = {
     renderer: 'threejs',
     modelKey: 'sdk',
     voice: 'en-US-JennyNeural',
+    elevenVoiceId: 'EXAVITQu4vr4xnSDxMaL', // Bella — warm, clear female
+    openaiVoice: 'nova',
     //
     // AvatarSDK MetaPerson — blobby/blended shapes, forgiving of heuristic errors.
     // Reduce if tongue protrudes.
@@ -83,6 +92,8 @@ export const AVATAR_PROFILES = {
     renderer: 'threejs',
     modelKey: 'rpm',
     voice: 'en-US-AriaNeural',
+    elevenVoiceId: 'EXAVITQu4vr4xnSDxMaL', // Bella — same Aria persona as aria_sdk
+    openaiVoice: 'nova',
     //
     // RPM Oculus visemes — highly distinct shapes designed for audio-driven
     // phoneme detection. Low weights prevent heuristic errors looking jarring.
@@ -114,6 +125,8 @@ export const AVATAR_PROFILES = {
     renderer: 'threejs',
     modelKey: 'metahuman',
     voice: 'en-US-EricNeural',
+    elevenVoiceId: 'nPczCjzI2devNBz1zQrb', // Brian — warm, mature male
+    openaiVoice: 'onyx',
     //
     // AvatarSDK MetaPerson export — same model type as aria_sdk.
     // Viseme shapes (aa, ih, ou, oh, PP, FF…) are direct morph targets.
@@ -146,6 +159,8 @@ export const AVATAR_PROFILES = {
     description: 'Reallusion CC4 character (Unity)',
     renderer: 'unity',
     voice: 'en-US-JennyNeural',
+    elevenVoiceId: 'EXAVITQu4vr4xnSDxMaL', // Bella — same Aria persona
+    openaiVoice: 'nova',
     // CC4 uses its own native blendshape set (see blendshapeTranslator.js), not
     // ARKit. visemeWeights is null so blendshapeTranslator uses its built-in
     // CC4_DEFAULT_WEIGHT scalar.

--- a/src/features/avatar/config/avatarProfiles.ts
+++ b/src/features/avatar/config/avatarProfiles.ts
@@ -158,9 +158,10 @@ export const AVATAR_PROFILES = {
     label: 'CC4',
     description: 'Reallusion CC4 character (Unity)',
     renderer: 'unity',
-    voice: 'en-US-JennyNeural',
-    elevenVoiceId: 'EXAVITQu4vr4xnSDxMaL', // Bella — same Aria persona
-    openaiVoice: 'nova',
+    // The CC4 character is HD_Aaron — male voices across all providers.
+    voice: 'en-US-EricNeural',
+    elevenVoiceId: 'nPczCjzI2devNBz1zQrb', // Brian — warm, mature male
+    openaiVoice: 'onyx',
     // CC4 uses its own native blendshape set (see blendshapeTranslator.js), not
     // ARKit. visemeWeights is null so blendshapeTranslator uses its built-in
     // CC4_DEFAULT_WEIGHT scalar.

--- a/src/features/settings/screens/ProfileScreen.js
+++ b/src/features/settings/screens/ProfileScreen.js
@@ -256,7 +256,7 @@ export const ProfileScreen = ({ navigation }) => {
     textSize, textScale, setTextSize,
     hapticFeedback, audioEnabled, avatarEnabled, autoPlayResponses,
     updateSetting, toggleDarkMode, triggerHaptic,
-    darkMode, highContrast, subtitlesEnabled, conciseMode, colors,
+    darkMode, highContrast, subtitlesEnabled, conciseMode, handsFreeMode, fastVoiceMode, colors,
   } = useSettings();
   const [apiKey, setApiKey]               = useState(null);
   const [elevenLabsKey, setElevenLabsKey] = useState(null);
@@ -499,6 +499,26 @@ export const ProfileScreen = ({ navigation }) => {
               sublabel="Shorter answers — no filler words or jargon"
               value={conciseMode}
               onToggle={(v) => updateSetting('conciseMode', v)}
+              isLast={false}
+            />
+
+            <ToggleRow
+              icon="hand-back-right-outline"
+              iconColor={Colors.primary}
+              label="Hands-free Conversation"
+              sublabel="Aria notices when you finish speaking — no need to tap stop"
+              value={handsFreeMode}
+              onToggle={(v) => { triggerHaptic('light'); updateSetting('handsFreeMode', v); }}
+              isLast={false}
+            />
+
+            <ToggleRow
+              icon="run-fast"
+              iconColor={Colors.accent}
+              label="Faster Voice Responses"
+              sublabel="Aria starts speaking sooner — turn off if audio sounds choppy"
+              value={fastVoiceMode}
+              onToggle={(v) => { triggerHaptic('light'); updateSetting('fastVoiceMode', v); }}
               isLast
             />
           </Section>

--- a/src/features/voice/hooks/useAvatarConversation.js
+++ b/src/features/voice/hooks/useAvatarConversation.js
@@ -1,11 +1,18 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { Audio } from 'expo-av';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as FileSystem from 'expo-file-system/legacy';
 import { openaiService } from '@/lib/openaiService';
 import { tts } from '@/lib/tts/ttsService';
+import { selectTtsMode, markTtsDegraded } from '@/lib/tts/ttsMode';
+import { createElevenLabsStream } from '@/lib/tts/elevenLabsStreamService';
+import { elevenLabsService } from '@/lib/tts/elevenLabsService';
+import { createStreamingVisemeAccumulator } from '@/lib/lipsync/streamingVisemeAccumulator';
+import { prewarmVoicePipeline } from '@/lib/voice/prewarm';
+import { ELEVEN_STREAM_SAMPLE_RATE, VOICE_SPECULATIVE_RAG } from '@/lib/voice/voiceConfig';
+import { createSpeculativeRag } from '@/lib/rag/speculativeRetrieval';
+import { startSttSession } from '@/lib/stt/sttService';
 import { detectSentiment } from '@/lib/sentiment/detectSentiment';
 import { useSettings } from '@/context/SettingsContext';
+import { createSentenceSplitter } from '@/features/voice/sentenceTracker';
 import { AVATAR_PROFILES, DEFAULT_AVATAR_ID } from '@/features/avatar/config/avatarProfiles';
 
 // ─── Voice state machine ──────────────────────────────────────────────────────
@@ -15,36 +22,6 @@ export const VoiceState = {
   PROCESSING: 'processing',
   SPEAKING:   'speaking',
 };
-
-// Whisper-optimised recording: 16 kHz mono reduces upload size ~4× vs HIGH_QUALITY
-// with no accuracy loss (Whisper resamples to 16 kHz internally).
-const WHISPER_RECORDING_OPTIONS = {
-  isMeteringEnabled: false,
-  android: {
-    extension: '.m4a',
-    outputFormat: Audio.AndroidOutputFormat.MPEG_4,
-    audioEncoder: Audio.AndroidAudioEncoder.AAC,
-    sampleRate: 16000,
-    numberOfChannels: 1,
-    bitRate: 32000,
-  },
-  ios: {
-    extension: '.m4a',
-    outputFormat: Audio.IOSOutputFormat.MPEG4AAC,
-    audioQuality: Audio.IOSAudioQuality.LOW,
-    sampleRate: 16000,
-    numberOfChannels: 1,
-    bitRate: 32000,
-    linearPCMBitDepth: 16,
-    linearPCMIsBigEndian: false,
-    linearPCMIsFloat: false,
-  },
-};
-
-// Secondary sentence split: fire TTS early when a sentence buffer exceeds this
-// length and contains a comma/semicolon, avoiding long silences on clause-heavy
-// responses before the first .!? boundary arrives.
-const EARLY_CHUNK_CHARS = 150;
 
 // Shared AsyncStorage key with ChatScreen — both read/write the same array.
 const MESSAGES_KEY = 'chat_messages_v1';
@@ -58,8 +35,10 @@ const MAX_QUERY_CHARS = 1000;
  * purely presentational.
  *
  * Pipeline overview:
- *   1. startRecording()     — expo-av records microphone audio
- *   2. stopAndTranscribe()  — Whisper transcribes the recording
+ *   1. startRecording()     — sttService streams live partials while the user
+ *      talks (expo-speech-recognition), or records for Whisper as fallback
+ *   2. stopAndTranscribe()  — finalizes the STT session (near-instant on the
+ *      live path; upload round trip only on the Whisper fallback)
  *   3. processQuery(text)   — runs the streaming conversation loop:
  *        a. producerTask(): chatStream() yields LLM tokens; sentence boundaries
  *           detected via punctuation (and early comma chunking); each complete
@@ -93,17 +72,32 @@ export function useAvatarConversation({ avatarRef }) {
   const {
     audioEnabled, conciseMode,
     responseStyle, jargonMode, ariaPersonality, isCaregiversSetup, speechRate,
-    selectedAvatarId,
+    selectedAvatarId, handsFreeMode, fastVoiceMode,
   } = useSettings();
 
   // Resolve the active avatar profile so viseme weights match the loaded model.
   const avatarProfile  = AVATAR_PROFILES[selectedAvatarId ?? DEFAULT_AVATAR_ID] ?? AVATAR_PROFILES[DEFAULT_AVATAR_ID];
   const visemeWeights  = avatarProfile.visemeWeights;
   const avatarVoice    = avatarProfile.voice ?? null;
+  const ttsVoiceOptions = {
+    voice: avatarVoice,
+    elevenVoiceId: avatarProfile.elevenVoiceId ?? null,
+    openaiVoice: avatarProfile.openaiVoice ?? null,
+  };
 
-  const recordingRef = useRef(null);
-  const abortRef     = useRef(false);  // set true when user stops mid-response
-  const historyRef   = useRef([]);     // kept in sync so callbacks always see latest
+  const sttSessionRef = useRef(null);  // active STT session (live or whisper)
+  const abortRef      = useRef(false); // set true when user stops mid-response
+  const historyRef    = useRef([]);    // kept in sync so callbacks always see latest
+  const lastPartialRef = useRef('');   // latest live STT partial (speculative RAG input)
+  const activeStreamRef = useRef(null); // { abort } for the in-flight TTS stream (barge-in)
+  const speculativeRef  = useRef(null); // per-turn speculative RAG session
+
+  // Refs so STT-session callbacks (created in startRecording) always call the
+  // CURRENT versions of these functions without stale closures.
+  const stopAndTranscribeRef = useRef(null);
+  const startRecordingRef    = useRef(null);
+  const voiceStateRef        = useRef(VoiceState.IDLE);
+  useEffect(() => { voiceStateRef.current = voiceState; }, [voiceState]);
 
   // Keep historyRef in sync with React state
   useEffect(() => {
@@ -134,7 +128,11 @@ export function useAvatarConversation({ avatarRef }) {
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      recordingRef.current?.stopAndUnloadAsync().catch(() => {});
+      sttSessionRef.current?.cancel();
+      sttSessionRef.current = null;
+      speculativeRef.current?.cancel();
+      speculativeRef.current = null;
+      activeStreamRef.current?.abort();
       avatarRef.current?.stopAudio();
     };
   }, [avatarRef]);
@@ -143,7 +141,7 @@ export function useAvatarConversation({ avatarRef }) {
   // Producer-consumer pattern: LLM streaming and TTS playback run concurrently.
   // The consumer starts as soon as the first sentence is queued — it does NOT
   // wait for the full LLM response before playing the first audio segment.
-  const processQuery = useCallback(async (userText, t0 = Date.now(), sttDoneAt = null) => {
+  const processQuery = useCallback(async (userText, t0 = Date.now(), sttDoneAt = null, preRetrievedChunks = null) => {
     if (!userText.trim()) return;
     // Cap transcript length: STT can produce unbounded text (the text path caps
     // at 500 chars), and an over-long query inflates embedding + prompt tokens.
@@ -160,39 +158,184 @@ export function useAvatarConversation({ avatarRef }) {
     // ── Shared async queue (single consumer, Hermes-safe) ────────────────────
     // JS is single-threaded so array writes are never truly concurrent.
     // The notify slot holds at most one waiter (only the consumer ever sets it).
+    // In streaming mode the queue idles empty — it is also the FALLBACK target:
+    // a mid-stream WebSocket failure requeues unspoken sentences here and the
+    // consumer plays them through the classic REST cascade.
     const queue = { promises: [], done: false, notify: null };
     const wake  = () => { const n = queue.notify; queue.notify = null; n?.(); };
 
-    // ── Producer: stream LLM → split sentences → enqueue TTS promises ────────
+    // ── Streaming TTS state (ElevenLabs WebSocket → WebView PCM chunks) ──────
+    let streamingActive = false;
+    if (audioEnabled && fastVoiceMode && avatarRef.current?.supportsStreamingAudio) {
+      streamingActive = (await selectTtsMode()) === 'eleven-stream';
+    }
+
+    const sessionId = `s_${Date.now()}`;
+    let ttsStream = null;
+    let accumulator = null;
+    let streamFailed = false;
+    let sessionStarted = false;         // first audio chunk reached the WebView
+    const sentences = [];               // { text, emotion, sentCharStart, sentCharEnd }
+    let sentCharCount = 0;              // chars actually sent over the WS (normalized)
+    const charTimes = [];               // absolute stream-time (sec) per sent char
+    let audioStartWallclock = null;     // Date.now() when playback actually started
+    let nextSubtitleIdx = 0;
+    let spokenIdx = -1;                 // last sentence whose subtitle was shown
+    const subtitleTimers = [];
+    let wsFinalResolve = null;
+    const wsFinalPromise = new Promise(r => { wsFinalResolve = r; });
+
+    // Subtitles/emotion are synced to PLAYBACK position (synthesis runs far
+    // ahead of audio): sentence k's start char maps to a stream time via the
+    // alignment charTimes, then to a wallclock timer from the audio anchor.
+    const scheduleSubtitles = () => {
+      if (audioStartWallclock == null) return;
+      while (nextSubtitleIdx < sentences.length) {
+        const s = sentences[nextSubtitleIdx];
+        if (s.sentCharStart >= charTimes.length) break; // timing not yet known
+        const streamSec = charTimes[Math.max(Math.min(s.sentCharStart, charTimes.length - 1), 0)];
+        const delay = Math.max(0, audioStartWallclock + streamSec * 1000 - Date.now());
+        const idx = nextSubtitleIdx;
+        subtitleTimers.push(setTimeout(() => {
+          if (abortRef.current || streamFailed) return;
+          setCurrentSubtitle(sentences[idx].text);
+          avatarRef.current?.setSpeechEmotion?.(sentences[idx].emotion);
+          spokenIdx = idx;
+        }, delay));
+        nextSubtitleIdx++;
+      }
+    };
+
+    // Mid-stream failure: degrade to the REST cascade for the unspoken tail
+    // (and for the rest of the session — sticky). Worst case equals the
+    // pre-streaming pipeline.
+    const handleStreamFailure = (err) => {
+      if (streamFailed || abortRef.current) return;
+      streamFailed = true;
+      markTtsDegraded(err?.message ?? String(err));
+      subtitleTimers.forEach(clearTimeout);
+      try { ttsStream?.abort(); } catch {}
+      avatarRef.current?.stopAudio(); // kill partial stream audio in the WebView
+      const replayFrom = Math.max(spokenIdx, 0);
+      for (let k = replayFrom; k < sentences.length; k++) {
+        addSegment(sentences[k].text);
+      }
+      wsFinalResolve();
+    };
+
+    if (streamingActive) {
+      accumulator = createStreamingVisemeAccumulator({ visemeWeights });
+      const elevenKey = await elevenLabsService.getApiKey();
+      ttsStream = createElevenLabsStream({
+        apiKey: elevenKey,
+        voiceId: ttsVoiceOptions.elevenVoiceId ?? 'nPczCjzI2devNBz1zQrb',
+        speechRate,
+        onTextSent: (text) => { sentCharCount += text.length; },
+        onAudioChunk: ({ pcmBase64, durationSec, alignment }) => {
+          if (abortRef.current || streamFailed) return;
+          const { frames, charTimes: newTimes } = accumulator.push(alignment, durationSec);
+          for (const ct of newTimes) charTimes.push(ct);
+          if (!sessionStarted) {
+            sessionStarted = true;
+            pts.tts_first_chunk = Date.now();
+            console.log(`[LATENCY] tts_first_chunk_ms +${pts.tts_first_chunk - t0}`);
+            avatarRef.current?.setOnAudioStart(() => {
+              if (!pts.audio_started) {
+                pts.audio_started = Date.now();
+                console.log(`[LATENCY] avatar_audio_started_ms +${pts.audio_started - t0}`);
+              }
+              audioStartWallclock = Date.now();
+              setVoiceState(VoiceState.SPEAKING);
+              scheduleSubtitles();
+            });
+            avatarRef.current?.startStreamingPlayback(
+              sessionId, ELEVEN_STREAM_SAMPLE_RATE, sentences[0]?.emotion ?? 'neutral');
+          }
+          avatarRef.current?.appendAudioChunk(sessionId, pcmBase64, frames);
+          scheduleSubtitles();
+        },
+        onFinal: () => {
+          // Release the held trailing word's frames (audio already scheduled).
+          const { frames } = accumulator.flush();
+          if (frames.length) avatarRef.current?.appendAudioChunk(sessionId, '', frames);
+          wsFinalResolve();
+        },
+        onError: handleStreamFailure,
+      });
+
+      // Barge-in hook: stopAudio() aborts the socket and unblocks the drain.
+      activeStreamRef.current = {
+        abort: () => {
+          try { ttsStream?.abort(); } catch {}
+          subtitleTimers.forEach(clearTimeout);
+          wsFinalResolve();
+        },
+      };
+
+      // Open in parallel with RAG + the LLM request — the WS handshake
+      // (~200–300 ms) hides entirely inside LLM time-to-first-token.
+      ttsStream.open().then(() => {
+        pts.ws_open = Date.now();
+        console.log(`[LATENCY] ws_open_ms +${pts.ws_open - t0}`);
+      }).catch(handleStreamFailure);
+    }
+
+    // ── REST segment queue (legacy path + streaming fallback target) ─────────
+    let firstSeg = true;
+    const addSegment = (text) => {
+      const clean = text.trim();
+      if (!clean || !audioEnabled) return;
+
+      const emotion = detectSentiment(clean);
+
+      if (firstSeg) {
+        pts.first_sentence = pts.first_sentence ?? Date.now();
+        pts.tts_start = Date.now();
+        console.log(`[LATENCY] tts_first_request_start_ms +${pts.tts_start - t0}`);
+        const p = tts(clean, { speechRate, visemeWeights, ...ttsVoiceOptions }).then(result => {
+          pts.tts_ready = Date.now();
+          console.log(`[LATENCY] tts_first_audio_ready_ms +${pts.tts_ready - t0}`);
+          return { ...result, text: clean, emotion };
+        });
+        queue.promises.push(p);
+        firstSeg = false;
+      } else {
+        queue.promises.push(tts(clean, { speechRate, visemeWeights, ...ttsVoiceOptions }).then(result => ({ ...result, text: clean, emotion })));
+      }
+      wake();
+    };
+
+    // Sentence boundary handler — routes to the WS stream or the REST queue.
+    const handleSentence = (text) => {
+      const clean = text.trim();
+      if (!clean || !audioEnabled) return;
+
+      if (streamingActive && !streamFailed) {
+        if (sentences.length === 0) {
+          pts.first_sentence = Date.now();
+          console.log(`[LATENCY] first_sentence_ready_ms +${pts.first_sentence - t0}`);
+        }
+        // flush() forces generation of everything buffered server-side, giving
+        // a clean prosody break; the sentence's chars are all sent by now, so
+        // the cumulative counter is this sentence's end offset.
+        ttsStream.flush();
+        const sentCharStart = sentences.length ? sentences[sentences.length - 1].sentCharEnd : 0;
+        sentences.push({ text: clean, emotion: detectSentiment(clean), sentCharStart, sentCharEnd: sentCharCount });
+        scheduleSubtitles();
+      } else {
+        if (sentences.length === 0 && firstSeg && !pts.first_sentence) {
+          pts.first_sentence = Date.now();
+          console.log(`[LATENCY] first_sentence_ready_ms +${pts.first_sentence - t0}`);
+        }
+        addSegment(clean);
+      }
+    };
+
+    // ── Producer: stream LLM → split sentences → WS stream or TTS queue ──────
     const producerTask = async () => {
       const history = historyRef.current;
       let fullText  = '';
-      let buf       = '';
-      let firstSeg  = true;
-
-      const addSegment = (text) => {
-        const clean = text.trim();
-        if (!clean || !audioEnabled) return;
-
-        const emotion = detectSentiment(clean);
-
-        if (firstSeg) {
-          pts.first_sentence = Date.now();
-          console.log(`[LATENCY] first_sentence_ready_ms +${pts.first_sentence - t0}`);
-          pts.tts_start = Date.now();
-          console.log(`[LATENCY] tts_first_request_start_ms +${pts.tts_start - t0}`);
-          const p = tts(clean, { speechRate, visemeWeights, voice: avatarVoice }).then(result => {
-            pts.tts_ready = Date.now();
-            console.log(`[LATENCY] tts_first_audio_ready_ms +${pts.tts_ready - t0}`);
-            return { ...result, text: clean, emotion };
-          });
-          queue.promises.push(p);
-          firstSeg = false;
-        } else {
-          queue.promises.push(tts(clean, { speechRate, visemeWeights, voice: avatarVoice }).then(result => ({ ...result, text: clean, emotion })));
-        }
-        wake();
-      };
+      const splitter = createSentenceSplitter();
 
       let citedSources = [];
       try {
@@ -215,7 +358,12 @@ export function useAvatarConversation({ avatarRef }) {
 
         let firstChunk = true;
         for await (const chunk of openaiService.chatStream(userText, history, timingCbs,
-            { conciseMode, responseStyle, jargonMode, ariaPersonality, isCaregiversSetup })) {
+            { conciseMode, responseStyle, jargonMode, ariaPersonality, isCaregiversSetup,
+              // Voice turns are serialized by the state machine — pacing here is
+              // pure dead time on the hot path (up to 750 ms before every reply).
+              skipThrottle: true,
+              // Chunks retrieved speculatively during live STT (or null).
+              preRetrievedChunks })) {
           if (abortRef.current) break;
           if (firstChunk) {
             pts.first_token = Date.now();
@@ -223,27 +371,29 @@ export function useAvatarConversation({ avatarRef }) {
             firstChunk = false;
           }
           fullText += chunk;
-          buf      += chunk;
 
-          // Primary split: sentence boundaries on .!?
-          // Uses \x1F delimiter trick to avoid lookbehind (unsupported in Hermes).
-          const marked = buf.replace(/([.!?])\s+/g, '$1\x1F');
-          const parts  = marked.split('\x1F');
-          parts.slice(0, -1).forEach(s => addSegment(s));
-          buf = parts[parts.length - 1];
-
-          // Secondary split: fire TTS early when buffer is long and contains a
-          // natural pause point, so clause-heavy responses don't block first audio.
-          if (buf.length > EARLY_CHUNK_CHARS) {
-            const splitIdx = Math.max(buf.lastIndexOf(','), buf.lastIndexOf(';'));
-            if (splitIdx > 15) {
-              addSegment(buf.slice(0, splitIdx + 1));
-              buf = buf.slice(splitIdx + 1).trimStart();
-            }
+          // Forward tokens to the WS immediately (sub-sentence first audio);
+          // sentence boundaries then trigger flush + subtitle records.
+          if (streamingActive && !streamFailed && audioEnabled) {
+            ttsStream.sendText(chunk);
           }
+          for (const sentence of splitter.push(chunk)) handleSentence(sentence);
         }
 
-        if (buf.trim() && !abortRef.current) addSegment(buf);
+        if (!abortRef.current) {
+          const rest = splitter.finish();
+          if (rest) handleSentence(rest);
+        }
+
+        // Streaming drain: close WS input, wait for the server's final audio,
+        // then wait for the WebView to finish playing the scheduled chunks.
+        if (streamingActive && !streamFailed && !abortRef.current) {
+          ttsStream.end();
+          await wsFinalPromise;
+          if (sessionStarted && !streamFailed && !abortRef.current) {
+            await avatarRef.current?.endStreamingPlayback(sessionId);
+          }
+        }
       } finally {
         setConversationHistory(prev => [
           ...prev,
@@ -292,10 +442,14 @@ export function useAvatarConversation({ avatarRef }) {
         if (firstPlay) {
           pts.avatar_play = Date.now();
           console.log(`[LATENCY] avatar_play_request_ms +${pts.avatar_play - t0}`);
-          // One-shot callback: fires when WebView signals audio has actually started
+          // One-shot callback: fires when WebView signals audio has actually
+          // started. Guarded so a streaming→REST fallback keeps the FIRST
+          // audible moment as the latency checkpoint.
           avatarRef.current?.setOnAudioStart(() => {
-            pts.audio_started = Date.now();
-            console.log(`[LATENCY] avatar_audio_started_ms +${pts.audio_started - t0}`);
+            if (!pts.audio_started) {
+              pts.audio_started = Date.now();
+              console.log(`[LATENCY] avatar_audio_started_ms +${pts.audio_started - t0}`);
+            }
           });
           firstPlay = false;
         }
@@ -319,49 +473,89 @@ export function useAvatarConversation({ avatarRef }) {
       console.error('[useAvatarConversation] processQuery error:', err);
       setError(err.message ?? 'Something went wrong. Please try again.');
     } finally {
+      subtitleTimers.forEach(clearTimeout);
+      try { ttsStream?.abort(); } catch {} // no-op if the stream completed cleanly
+      activeStreamRef.current = null;
       setCurrentSubtitle('');
       setVoiceState(VoiceState.IDLE);
       const d = (a, b) => (a != null && b != null) ? a - b : null;
       console.log('[LATENCY SUMMARY]', JSON.stringify({
+        mode:              streamingActive ? (streamFailed ? 'streaming-degraded' : 'streaming') : 'legacy',
         stt_ms:            d(pts.stt_done,      t0),
         rag_ms:            d(pts.rag_done,       pts.rag_start),
         llm_to_token_ms:   d(pts.first_token,    pts.llm_send),
         first_sentence_ms: d(pts.first_sentence, pts.first_token),
+        ws_open_ms:        d(pts.ws_open,        t0),
+        tts_first_chunk_ms: d(pts.tts_first_chunk, t0),
         tts_first_ms:      d(pts.tts_ready,      pts.tts_start),
         to_first_audio_ms: d(pts.audio_started,  t0),
       }));
     }
-  }, [avatarRef, audioEnabled]);
+  }, [avatarRef, audioEnabled, fastVoiceMode, conciseMode, responseStyle, jargonMode,
+      ariaPersonality, isCaregiversSetup, speechRate, selectedAvatarId]);
 
   // ─── Recording ─────────────────────────────────────────────────────────────
 
   const startRecording = useCallback(async () => {
     try {
-      const { status } = await Audio.requestPermissionsAsync();
-      if (status !== 'granted') return;
+      // While the user talks, pay the cold-start costs (SecureStore reads,
+      // TLS handshakes) so the post-stop hot path hits warm connections.
+      prewarmVoicePipeline();
 
-      if (recordingRef.current) {
-        await recordingRef.current.stopAndUnloadAsync().catch(() => {});
-        recordingRef.current = null;
+      if (sttSessionRef.current) {
+        sttSessionRef.current.cancel();
+        sttSessionRef.current = null;
       }
 
-      await Audio.setAudioModeAsync({
-        allowsRecordingIOS: true,
-        playsInSilentModeIOS: true,
+      lastPartialRef.current = '';
+      const recordingStartedAt = Date.now();
+      let loggedFirstPartial = false;
+
+      // Fresh speculative-RAG session per turn: retrieval fires on a
+      // stabilized partial while the user is still talking.
+      speculativeRef.current?.cancel();
+      speculativeRef.current = VOICE_SPECULATIVE_RAG
+        ? createSpeculativeRag({ search: (q) => openaiService.search(q) })
+        : null;
+
+      const session = await startSttSession({
+        handsFree: handsFreeMode,
+        onPartial: (text) => {
+          lastPartialRef.current = text;
+          speculativeRef.current?.onPartial(text.slice(0, MAX_QUERY_CHARS));
+          if (!loggedFirstPartial) {
+            loggedFirstPartial = true;
+            console.log(`[LATENCY] stt_partial_first_ms +${Date.now() - recordingStartedAt} (from record start)`);
+          }
+        },
+        onEndOfSpeech: ({ reason }) => {
+          if (voiceStateRef.current !== VoiceState.LISTENING) return;
+          if (reason === 'lead-silence') {
+            // User never spoke — return to idle quietly instead of processing.
+            sttSessionRef.current?.cancel();
+            sttSessionRef.current = null;
+            setVoiceState(VoiceState.IDLE);
+            return;
+          }
+          stopAndTranscribeRef.current?.();
+        },
+        onError: (err) => {
+          console.warn('[useAvatarConversation] STT session error:', err?.message ?? err);
+        },
       });
 
-      const { recording } = await Audio.Recording.createAsync(WHISPER_RECORDING_OPTIONS);
-      recordingRef.current = recording;
+      sttSessionRef.current = session;
       setVoiceState(VoiceState.LISTENING);
     } catch (err) {
+      if (err?.code === 'permission-denied') return; // same silent no-op as before
       console.error('[useAvatarConversation] startRecording:', err);
-      await Audio.setAudioModeAsync({ allowsRecordingIOS: false }).catch(() => {});
     }
-  }, []);
+  }, [handsFreeMode]);
 
   const stopAndTranscribe = useCallback(async () => {
-    const rec = recordingRef.current;
-    if (!rec) return;
+    const session = sttSessionRef.current;
+    if (!session) return;
+    sttSessionRef.current = null;
 
     const t0 = Date.now();
     console.log(`[LATENCY] recording_stop_ms +0`);
@@ -369,39 +563,52 @@ export function useAvatarConversation({ avatarRef }) {
     setVoiceState(VoiceState.PROCESSING);
 
     try {
-      await rec.stopAndUnloadAsync();
-      const uri = rec.getURI();
-      recordingRef.current = null;
-
-      await Audio.setAudioModeAsync({
-        allowsRecordingIOS: false,
-        playsInSilentModeIOS: true,
-      });
-
       console.log(`[LATENCY] stt_start_ms +${Date.now() - t0}`);
-      const transcript = await openaiService.transcribe(uri);
+      const { transcript, source } = await session.stop();
       const sttDoneAt = Date.now();
-      console.log(`[LATENCY] stt_done_ms +${sttDoneAt - t0}`);
+      console.log(`[LATENCY] stt_final_ms +${sttDoneAt - t0} source=${source}`);
 
       if (!transcript) {
+        speculativeRef.current?.cancel();
+        speculativeRef.current = null;
         setVoiceState(VoiceState.IDLE);
         return;
       }
 
-      // Clean up temp recording file before proceeding
-      FileSystem.deleteAsync(uri, { idempotent: true }).catch(() => {});
+      // Speculative RAG: reuse retrieval fired during speech when the final
+      // transcript is lexically close to the stabilized partial.
+      let preRetrievedChunks = null;
+      if (speculativeRef.current) {
+        const spec = await speculativeRef.current.resolve(transcript.slice(0, MAX_QUERY_CHARS));
+        speculativeRef.current = null;
+        console.log(`[LATENCY] rag_speculative=${spec.status} +${Date.now() - t0}`);
+        if (spec.status === 'hit') preRetrievedChunks = spec.chunks;
+      }
 
       // Pass t0 and sttDoneAt so processQuery shares the same timing anchor
-      await processQuery(transcript, t0, sttDoneAt);
+      await processQuery(transcript, t0, sttDoneAt, preRetrievedChunks);
+
+      // Hands-free: re-arm listening after a completed (not interrupted)
+      // response so the conversation continues without another tap. The mic
+      // stays off while the avatar speaks — echo would feed the recognizer.
+      // (abortRef is the barge-in signal; state may not have re-rendered yet.)
+      if (handsFreeMode && !abortRef.current) {
+        startRecordingRef.current?.();
+      }
     } catch (err) {
       console.error('[useAvatarConversation] stopAndTranscribe:', err);
       setError(err.message ?? 'Could not transcribe audio. Please try again.');
       setVoiceState(VoiceState.IDLE);
     }
-  }, [processQuery]);
+  }, [processQuery, handsFreeMode]);
+
+  // Keep the callback refs current (STT session callbacks + hands-free re-arm).
+  useEffect(() => { stopAndTranscribeRef.current = stopAndTranscribe; }, [stopAndTranscribe]);
+  useEffect(() => { startRecordingRef.current = startRecording; }, [startRecording]);
 
   const stopAudio = useCallback(() => {
     abortRef.current = true;
+    activeStreamRef.current?.abort(); // close the TTS WebSocket + unblock the drain
     avatarRef.current?.stopAudio();
   }, [avatarRef]);
 
@@ -418,11 +625,12 @@ export function useAvatarConversation({ avatarRef }) {
   }, [voiceState, startRecording, stopAndTranscribe, stopAudio]);
 
   const handleStop = useCallback(async () => {
-    if (recordingRef.current) {
-      await recordingRef.current.stopAndUnloadAsync().catch(() => {});
-      await Audio.setAudioModeAsync({ allowsRecordingIOS: false }).catch(() => {});
-      recordingRef.current = null;
+    if (sttSessionRef.current) {
+      sttSessionRef.current.cancel();
+      sttSessionRef.current = null;
     }
+    speculativeRef.current?.cancel();
+    speculativeRef.current = null;
     stopAudio();
     setVoiceState(VoiceState.IDLE);
   }, [stopAudio]);

--- a/src/features/voice/screens/VoiceScreen.js
+++ b/src/features/voice/screens/VoiceScreen.js
@@ -25,6 +25,7 @@ import { Colors } from '@/theme/colors';
 import { Typography } from '@/theme/typography';
 import { useAvatarConversation, VoiceState } from '@/features/voice/hooks/useAvatarConversation';
 import { useSettings } from '@/context/SettingsContext';
+import { prewarmVoicePipeline } from '@/lib/voice/prewarm';
 
 import { AVATAR_PROFILES, AVATAR_PROFILE_LIST, DEFAULT_AVATAR_ID } from '@/features/avatar/config/avatarProfiles';
 
@@ -82,6 +83,12 @@ export const VoiceScreen = ({ navigation }) => {
       onClosed?.();
     });
   }, [menuAnim]);
+
+  // Warm API connections + credential caches while the user is still looking
+  // at the screen, so the first voice turn doesn't pay TLS/SecureStore costs.
+  useEffect(() => {
+    prewarmVoicePipeline();
+  }, []);
 
   // Load the avatar GLB for the selected profile + the backdrop, converting both to
   // base64 data URIs so the WebView GLTFLoader can read them without XHR size limits.

--- a/src/features/voice/sentenceTracker.js
+++ b/src/features/voice/sentenceTracker.js
@@ -1,0 +1,45 @@
+// Sentence-boundary splitter for the streamed LLM token feed — the single
+// definition shared by the legacy (per-sentence REST TTS) and streaming
+// (WebSocket TTS) producers, so both split identically by construction.
+//
+// Rules (unchanged from the original inline producer logic):
+//   Primary:   split after . ! ? followed by whitespace. Uses a \x1F delimiter
+//              substitution because Hermes doesn't support lookbehind.
+//   Secondary: when the pending buffer exceeds earlyChunkChars and contains a
+//              comma/semicolon past index 15, flush early — clause-heavy
+//              responses shouldn't hold back first audio.
+
+export const EARLY_CHUNK_CHARS = 150;
+
+export function createSentenceSplitter({ earlyChunkChars = EARLY_CHUNK_CHARS } = {}) {
+  let buf = '';
+
+  return {
+    /** Feed a token chunk; returns zero or more completed sentences. */
+    push(piece) {
+      buf += piece;
+      const out = [];
+
+      const marked = buf.replace(/([.!?])\s+/g, '$1\x1F');
+      const parts = marked.split('\x1F');
+      for (const s of parts.slice(0, -1)) out.push(s);
+      buf = parts[parts.length - 1];
+
+      if (buf.length > earlyChunkChars) {
+        const splitIdx = Math.max(buf.lastIndexOf(','), buf.lastIndexOf(';'));
+        if (splitIdx > 15) {
+          out.push(buf.slice(0, splitIdx + 1));
+          buf = buf.slice(splitIdx + 1).trimStart();
+        }
+      }
+      return out;
+    },
+
+    /** Stream over: returns the remaining partial sentence, or null. */
+    finish() {
+      const rest = buf.trim();
+      buf = '';
+      return rest || null;
+    },
+  };
+}

--- a/src/features/voice/sentenceTracker.test.js
+++ b/src/features/voice/sentenceTracker.test.js
@@ -1,0 +1,80 @@
+import { createSentenceSplitter, EARLY_CHUNK_CHARS } from './sentenceTracker';
+
+// Reference implementation: the exact splitting code that lived inline in
+// useAvatarConversation's producer before extraction. The splitter must stay
+// behaviourally identical — it feeds both the REST and streaming TTS paths.
+function referenceSplit(pieces) {
+  const out = [];
+  let buf = '';
+  for (const chunk of pieces) {
+    buf += chunk;
+    const marked = buf.replace(/([.!?])\s+/g, '$1\x1F');
+    const parts = marked.split('\x1F');
+    parts.slice(0, -1).forEach((s) => out.push(s));
+    buf = parts[parts.length - 1];
+    if (buf.length > EARLY_CHUNK_CHARS) {
+      const splitIdx = Math.max(buf.lastIndexOf(','), buf.lastIndexOf(';'));
+      if (splitIdx > 15) {
+        out.push(buf.slice(0, splitIdx + 1));
+        buf = buf.slice(splitIdx + 1).trimStart();
+      }
+    }
+  }
+  if (buf.trim()) out.push(buf);
+  return out;
+}
+
+function runSplitter(pieces) {
+  const splitter = createSentenceSplitter();
+  const out = [];
+  for (const p of pieces) out.push(...splitter.push(p));
+  const rest = splitter.finish();
+  if (rest) out.push(rest);
+  return out;
+}
+
+const tokenize = (text, size = 5) => {
+  const pieces = [];
+  for (let i = 0; i < text.length; i += size) pieces.push(text.slice(i, i + size));
+  return pieces;
+};
+
+describe('createSentenceSplitter', () => {
+  it('splits on sentence-final punctuation followed by whitespace', () => {
+    const out = runSplitter(['Hello there. How are you? Fine! Good.']);
+    expect(out).toEqual(['Hello there.', 'How are you?', 'Fine!', 'Good.']);
+  });
+
+  it('does not split on punctuation without trailing whitespace (decimals, abbreviations)', () => {
+    const out = runSplitter(['Take 1.5 mg daily. Then rest.']);
+    expect(out).toEqual(['Take 1.5 mg daily.', 'Then rest.']);
+  });
+
+  it('holds an incomplete sentence until finish()', () => {
+    const splitter = createSentenceSplitter();
+    expect(splitter.push('This never ends')).toEqual([]);
+    expect(splitter.finish()).toBe('This never ends');
+  });
+
+  it('finish() returns null for whitespace-only remainder', () => {
+    const splitter = createSentenceSplitter();
+    splitter.push('Done. ');
+    expect(splitter.finish()).toBeNull();
+  });
+
+  it('fires an early clause split when the buffer exceeds the threshold', () => {
+    const longClause = `${'word '.repeat(28)}pause,${' more'.repeat(10)}`; // >150 chars with a comma
+    const out = runSplitter([longClause]);
+    expect(out.length).toBeGreaterThan(1);
+    expect(out[0].endsWith(',')).toBe(true);
+  });
+
+  it.each([
+    ['single piece', ['Aria helps with morning routines. She can remind you about medication, meals, and appointments whenever needed. What would you like to know?']],
+    ['token-sized pieces', tokenize('Sundowning is common in dementia. Try keeping the evening calm, with soft lighting; avoid caffeine late in the day. Would a routine help? Yes!')],
+    ['clause-heavy long text', tokenize(`When someone with dementia becomes agitated in the late afternoon${', it can help to dim the lights'.repeat(6)}, and keep noise low. Stay calm.`)],
+    ['no trailing punctuation', tokenize('First point. Second point without an ending')],
+  ])('matches the original inline producer logic (%s)', (_name, pieces) => {
+    expect(runSplitter(pieces)).toEqual(referenceSplit(pieces));
+  });
+});

--- a/src/lib/lipsync/createVisemeTimeline.js
+++ b/src/lib/lipsync/createVisemeTimeline.js
@@ -117,6 +117,9 @@ function buildWordScales(characters) {
  * @param {object} [options.visemeWeights] - Per-avatar weight overrides (from avatarProfiles.js).
  *   When provided, these replace VISEME_WEIGHT from phonemeMap.js so each model can be tuned
  *   independently. Digraph weights are scaled proportionally via the aa weight ratio.
+ * @param {boolean} [options.streaming] - True when this alignment is a PARTIAL chunk of an
+ *   ongoing stream: skips applyFinalLowering (which would droop the mouth mid-sentence —
+ *   the stream's true end is handled by the player when the timeline runs out).
  */
 export function createVisemeTimeline(alignment, options = {}) {
   const { characters, character_start_times_seconds, character_end_times_seconds } = alignment;
@@ -217,7 +220,8 @@ export function createVisemeTimeline(alignment, options = {}) {
   }
 
   const totalDuration = character_end_times_seconds[characters.length - 1] || 0;
-  const frames        = applyFinalLowering(mergeConsecutiveSameViseme(rawFrames), totalDuration);
+  const merged        = mergeConsecutiveSameViseme(rawFrames);
+  const frames        = options.streaming ? merged : applyFinalLowering(merged, totalDuration);
 
   return { frames, totalDuration };
 }

--- a/src/lib/lipsync/createVisemeTimeline.streaming.test.js
+++ b/src/lib/lipsync/createVisemeTimeline.streaming.test.js
@@ -1,0 +1,49 @@
+import { createVisemeTimeline } from './createVisemeTimeline';
+
+// A sentence long enough (>400ms) that applyFinalLowering activates on the
+// non-streaming path: final-window frames get their weight ramped down.
+function alignmentFor(text, charMs = 60) {
+  const characters = text.split('');
+  return {
+    characters,
+    character_start_times_seconds: characters.map((_, i) => (i * charMs) / 1000),
+    character_end_times_seconds: characters.map((_, i) => ((i + 1) * charMs) / 1000),
+  };
+}
+
+describe('createVisemeTimeline streaming option', () => {
+  const alignment = alignmentFor('this is a fairly long sentence for testing purposes');
+
+  it('applies final lowering by default (one-shot REST path)', () => {
+    const oneShot = createVisemeTimeline(alignment, {});
+    const streaming = createVisemeTimeline(alignment, { streaming: true });
+
+    expect(oneShot.totalDuration).toBeCloseTo(streaming.totalDuration, 5);
+    expect(oneShot.frames.length).toBe(streaming.frames.length);
+
+    // In the lowering window (last 15% / 250ms) the one-shot weights must be
+    // strictly lower than the streaming weights for non-neutral frames.
+    const cutoff = oneShot.totalDuration - Math.min(oneShot.totalDuration * 0.15, 0.25);
+    let compared = 0;
+    for (let i = 0; i < oneShot.frames.length; i++) {
+      const a = oneShot.frames[i];
+      const b = streaming.frames[i];
+      if (a.viseme !== 'neutral' && a.time > cutoff && b.weight > 0) {
+        expect(a.weight).toBeLessThan(b.weight);
+        compared++;
+      }
+    }
+    expect(compared).toBeGreaterThan(0); // the window actually contained frames
+  });
+
+  it('leaves pre-window frames identical in both modes', () => {
+    const oneShot = createVisemeTimeline(alignment, {});
+    const streaming = createVisemeTimeline(alignment, { streaming: true });
+    const cutoff = oneShot.totalDuration - Math.min(oneShot.totalDuration * 0.15, 0.25);
+    for (let i = 0; i < oneShot.frames.length; i++) {
+      if (oneShot.frames[i].time <= cutoff) {
+        expect(oneShot.frames[i]).toEqual(streaming.frames[i]);
+      }
+    }
+  });
+});

--- a/src/lib/lipsync/streamingVisemeAccumulator.js
+++ b/src/lib/lipsync/streamingVisemeAccumulator.js
@@ -1,0 +1,117 @@
+// Converts ElevenLabs WebSocket per-chunk alignment into viseme frames in
+// ABSOLUTE stream time, ready to append to the WebView's live timeline.
+//
+// Two problems this solves that the one-shot path doesn't have:
+//
+// 1. Reference-frame ambiguity: each WS message's alignment times may be
+//    relative to that chunk OR to the whole stream depending on server
+//    behaviour. We detect at runtime: if a chunk's first char start is already
+//    at/after the stream position we've accounted for, times are stream-
+//    relative and used as-is; otherwise we add the running offset.
+//
+// 2. Word tearing: a word can be split across WS messages ("medic" + "ation").
+//    createVisemeTimeline's G2P pass would render two half-word frame sets.
+//    We hold back the trailing partial word (chars after the last whitespace)
+//    and prepend it to the next chunk's alignment.
+//
+// Usage per response turn:
+//   const acc = createStreamingVisemeAccumulator({ visemeWeights });
+//   ...on each WS message: frames = acc.push(alignment, pcmDurationSec);
+//   ...on stream end:      frames = acc.flush();
+
+import { createVisemeTimeline } from './createVisemeTimeline';
+
+const EPSILON_SEC = 0.25; // tolerance when classifying chunk- vs stream-relative times
+
+export function createStreamingVisemeAccumulator({ visemeWeights = null } = {}) {
+  let streamOffsetSec = 0;   // cumulative duration of all PCM audio received so far
+  let carry = null;          // { characters, starts, ends } — held-back trailing partial word
+
+  const toFrames = (characters, starts, ends) => {
+    if (!characters.length) return [];
+    const { frames } = createVisemeTimeline(
+      {
+        characters,
+        character_start_times_seconds: starts,
+        character_end_times_seconds: ends,
+      },
+      { visemeWeights: visemeWeights || undefined, streaming: true }
+    );
+    return frames;
+  };
+
+  return {
+    /**
+     * @param {object} alignment ElevenLabs WS alignment: { chars, charStartTimesMs, charDurationsMs }
+     * @param {number} pcmChunkDurationSec duration of the audio that CAME WITH this alignment
+     * @returns {{ frames: Array, charTimes: number[] }} viseme frames in absolute
+     *   stream time (may be empty while a partial word is held) plus the absolute
+     *   start time of every incoming alignment char — the cumulative char count
+     *   across pushes is the caller's subtitle-timing join key.
+     */
+    push(alignment, pcmChunkDurationSec) {
+      const chars = alignment?.chars ?? [];
+      const startsMs = alignment?.charStartTimesMs ?? [];
+      const durationsMs = alignment?.charDurationsMs ?? [];
+      if (!chars.length) {
+        streamOffsetSec += pcmChunkDurationSec || 0;
+        return { frames: [], charTimes: [] };
+      }
+
+      // Normalize to absolute stream seconds.
+      const firstStartSec = startsMs[0] / 1000;
+      const chunkRelative = firstStartSec < streamOffsetSec - EPSILON_SEC;
+      const base = chunkRelative ? streamOffsetSec : 0;
+
+      let characters = chars.slice();
+      let starts = startsMs.map((ms) => base + ms / 1000);
+      let ends = startsMs.map((ms, i) => base + (ms + (durationsMs[i] ?? 0)) / 1000);
+      const charTimes = starts.slice(); // times for the incoming chars only (pre-carry)
+
+      // Prepend the carried partial word from the previous chunk.
+      if (carry) {
+        characters = carry.characters.concat(characters);
+        starts = carry.starts.concat(starts);
+        ends = carry.ends.concat(ends);
+        carry = null;
+      }
+
+      // Hold back the trailing partial word (no whitespace after it yet) so
+      // G2P sees whole words. If the chunk is ALL one partial word, carry it
+      // entirely and emit nothing yet.
+      let lastSpace = -1;
+      for (let i = characters.length - 1; i >= 0; i--) {
+        if (/\s/.test(characters[i])) { lastSpace = i; break; }
+      }
+      if (lastSpace >= 0 && lastSpace < characters.length - 1) {
+        carry = {
+          characters: characters.slice(lastSpace + 1),
+          starts: starts.slice(lastSpace + 1),
+          ends: ends.slice(lastSpace + 1),
+        };
+        characters = characters.slice(0, lastSpace + 1);
+        starts = starts.slice(0, lastSpace + 1);
+        ends = ends.slice(0, lastSpace + 1);
+      } else if (lastSpace < 0) {
+        carry = { characters, starts, ends };
+        characters = [];
+        starts = [];
+        ends = [];
+      }
+
+      streamOffsetSec += pcmChunkDurationSec || 0;
+      return { frames: toFrames(characters, starts, ends), charTimes };
+    },
+
+    /** Emit any held-back trailing word at stream end. */
+    flush() {
+      if (!carry) return { frames: [], charTimes: [] };
+      const { characters, starts, ends } = carry;
+      carry = null;
+      return { frames: toFrames(characters, starts, ends), charTimes: [] };
+    },
+
+    /** Total seconds of audio pushed so far (the stream-time clock). */
+    getStreamOffsetSec: () => streamOffsetSec,
+  };
+}

--- a/src/lib/lipsync/streamingVisemeAccumulator.test.js
+++ b/src/lib/lipsync/streamingVisemeAccumulator.test.js
@@ -1,0 +1,71 @@
+import { createStreamingVisemeAccumulator } from './streamingVisemeAccumulator';
+
+// Build a WS-shaped alignment for a string: each char 50ms, starting at startMs.
+function alignmentFor(text, startMs = 0, charMs = 50) {
+  const chars = text.split('');
+  return {
+    chars,
+    charStartTimesMs: chars.map((_, i) => startMs + i * charMs),
+    charDurationsMs: chars.map(() => charMs),
+  };
+}
+
+describe('createStreamingVisemeAccumulator', () => {
+  it('emits frames in absolute stream time for a single chunk', () => {
+    const acc = createStreamingVisemeAccumulator({});
+    const { frames, charTimes } = acc.push(alignmentFor('hello world '), 0.6);
+    expect(frames.length).toBeGreaterThan(0);
+    expect(charTimes).toHaveLength(12);
+    expect(frames[0].time).toBeCloseTo(0, 3);
+    expect(acc.getStreamOffsetSec()).toBeCloseTo(0.6, 5);
+  });
+
+  it('offsets chunk-relative alignments by the accumulated stream time', () => {
+    const acc = createStreamingVisemeAccumulator({});
+    acc.push(alignmentFor('first part done '), 0.8);
+    // Second chunk restarts its clock at 0 → must be recognized as
+    // chunk-relative and shifted by +0.8s.
+    const { frames, charTimes } = acc.push(alignmentFor('second bit '), 0.55);
+    expect(charTimes[0]).toBeCloseTo(0.8, 3);
+    expect(frames[0].time).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it('passes through stream-relative alignments unchanged', () => {
+    const acc = createStreamingVisemeAccumulator({});
+    acc.push(alignmentFor('first part done ', 0), 0.8);
+    // Second chunk's timestamps continue from ~800ms → already absolute.
+    const { charTimes } = acc.push(alignmentFor('second bit ', 800), 0.55);
+    expect(charTimes[0]).toBeCloseTo(0.8, 3);
+  });
+
+  it('carries a split word across chunks so G2P sees whole words', () => {
+    const acc = createStreamingVisemeAccumulator({});
+    // 'medica' has no trailing space — must be held back entirely...
+    const first = acc.push(alignmentFor('take your medica'), 0.8);
+    const heldFrameTimes = first.frames.map((f) => f.time);
+    // ...only 'take your ' may produce frames in this push.
+    expect(Math.max(...heldFrameTimes)).toBeLessThan(0.5); // 'medica' starts at 10*50ms=0.5s
+    // The completed word arrives with the next chunk (chunk-relative times).
+    const second = acc.push(alignmentFor('tion now '), 0.45);
+    const times = second.frames.map((f) => f.time);
+    // Frames for 'medication' start where 'medica' started: 0.5s.
+    expect(Math.min(...times)).toBeCloseTo(0.5, 2);
+  });
+
+  it('flush() releases the held trailing word at stream end', () => {
+    const acc = createStreamingVisemeAccumulator({});
+    acc.push(alignmentFor('say goodbye'), 0.55); // 'goodbye' held (no trailing space)
+    const { frames } = acc.flush();
+    expect(frames.length).toBeGreaterThan(0);
+    expect(frames[0].time).toBeCloseTo(0.2, 2); // 'goodbye' starts at 4*50ms
+    // Second flush is a no-op.
+    expect(acc.flush().frames).toEqual([]);
+  });
+
+  it('handles alignment-less audio chunks by advancing the clock only', () => {
+    const acc = createStreamingVisemeAccumulator({});
+    const res = acc.push(null, 0.3);
+    expect(res.frames).toEqual([]);
+    expect(acc.getStreamOffsetSec()).toBeCloseTo(0.3, 5);
+  });
+});

--- a/src/lib/net/withTimeout.js
+++ b/src/lib/net/withTimeout.js
@@ -1,0 +1,27 @@
+// Shared AbortController timeout helper for hot-path network calls.
+// Every stage of the voice pipeline must be able to fail fast: a stalled
+// request with no timeout hangs the whole turn (there is no user-visible
+// spinner-escape on the voice screen).
+
+/**
+ * Returns an AbortSignal that fires after `ms`, plus a cancel() to clear the
+ * timer once the request settles (avoids stray timers keeping the JS thread
+ * alive and aborting a controller that's already done).
+ *
+ *   const t = timeoutSignal(5000);
+ *   try { await fetch(url, { signal: t.signal }); } finally { t.cancel(); }
+ */
+export function timeoutSignal(ms) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  return {
+    signal: controller.signal,
+    cancel: () => clearTimeout(timer),
+    abort: () => { clearTimeout(timer); controller.abort(); },
+  };
+}
+
+/** True when an error came from an aborted fetch/rpc (timeout or manual). */
+export function isAbortError(err) {
+  return err?.name === 'AbortError' || /abort/i.test(err?.message ?? '');
+}

--- a/src/lib/openaiService.js
+++ b/src/lib/openaiService.js
@@ -16,11 +16,21 @@ import { buildSystemPrompt, buildUserContent } from './rag/prompt';
 import { capBySourceFamily } from './rag/retrieval';
 import { extractCitations, createMarkerStripper } from './rag/citations';
 import { recordRetrieval } from './ragTelemetry';
+import { timeoutSignal } from './net/withTimeout';
 
 const SECURE_KEY = 'openai_api_key';
 const OPENAI_BASE = 'https://api.openai.com/v1';
 const EMBED_CACHE_MAX = 20;   // LRU of recent query embeddings (repeat/retry queries skip a network call)
 const MIN_REQUEST_INTERVAL_MS = 750; // client-side pacing between chat requests
+
+// Hot-path timeouts. A stalled request without one hangs the whole voice turn.
+// Embedding/search timeouts degrade to a zero-chunk answer (the v2 prompt
+// handles missing passages); the others surface as user-visible errors.
+const EMBED_TIMEOUT_MS = 5000;
+const SEARCH_TIMEOUT_MS = 4000;
+const WHISPER_TIMEOUT_MS = 15000;
+const LLM_TOTAL_TIMEOUT_MS = 60000;
+const LLM_TTFB_TIMEOUT_MS = 12000;
 
 class OpenAIAuthError extends Error {
   constructor(msg) { super(msg); this.name = 'OpenAIAuthError'; }
@@ -76,16 +86,23 @@ class OpenAIService {
 
   // ─── Raw OpenAI Calls ───────────────────────────────────────────────────────
 
-  async _callOpenAI(endpoint, body, apiKey) {
+  async _callOpenAI(endpoint, body, apiKey, { timeoutMs = null } = {}) {
     const key = apiKey ?? (await this.getApiKey());
-    const resp = await fetch(`${OPENAI_BASE}${endpoint}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${key}`,
-      },
-      body: JSON.stringify(body),
-    });
+    const t = timeoutMs ? timeoutSignal(timeoutMs) : null;
+    let resp;
+    try {
+      resp = await fetch(`${OPENAI_BASE}${endpoint}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${key}`,
+        },
+        body: JSON.stringify(body),
+        ...(t ? { signal: t.signal } : {}),
+      });
+    } finally {
+      t?.cancel();
+    }
 
     if (resp.status === 401) throw new OpenAIAuthError('Invalid API key');
     if (resp.status === 429) throw new OpenAIRateLimitError('Rate limit reached');
@@ -109,7 +126,7 @@ class OpenAIService {
     const data = await this._callOpenAI('/embeddings', {
       model: EMBEDDING_MODEL,
       input: text,
-    });
+    }, null, { timeoutMs: EMBED_TIMEOUT_MS });
     const embedding = data.data[0].embedding;
     this._embedCache.set(key, embedding);
     if (this._embedCache.size > EMBED_CACHE_MAX) {
@@ -122,12 +139,18 @@ class OpenAIService {
 
   async search(query, topK = TOP_K) {
     const queryEmbedding = await this._embedQuery(query);
-    const { data, error } = await supabase.rpc('match_chunks', {
-      query_embedding: queryEmbedding,
-      query_text: query,
-      match_count: topK * RETRIEVAL_OVERSAMPLE,
-      min_similarity: MIN_SIMILARITY,
-    });
+    const t = timeoutSignal(SEARCH_TIMEOUT_MS);
+    let data, error;
+    try {
+      ({ data, error } = await supabase.rpc('match_chunks', {
+        query_embedding: queryEmbedding,
+        query_text: query,
+        match_count: topK * RETRIEVAL_OVERSAMPLE,
+        min_similarity: MIN_SIMILARITY,
+      }).abortSignal(t.signal));
+    } finally {
+      t.cancel();
+    }
     if (error) throw new Error(`Supabase search error: ${error.message}`);
     return capBySourceFamily(data ?? [], topK, MAX_PER_SOURCE_FAMILY);
   }
@@ -138,15 +161,43 @@ class OpenAIService {
 
   async *chatStream(userMessage, conversationHistory = [], timingCbs = null,
                     { conciseMode = false, responseStyle = 'balanced', jargonMode = 'explain',
-                      ariaPersonality = 'warm', isCaregiversSetup = false } = {}) {
+                      ariaPersonality = 'warm', isCaregiversSetup = false,
+                      skipThrottle = false, preRetrievedChunks = null } = {}) {
     const apiKey = await this.getApiKey();
     if (!apiKey) throw new OpenAIAuthError('No API key configured');
 
-    await this._throttle();
+    // The voice pipeline is already serialized by its state machine, so pacing
+    // there is pure dead time on the hot path. Text chat keeps the throttle.
+    if (skipThrottle) {
+      this._lastRequestAt = Date.now();
+    } else {
+      await this._throttle();
+    }
+
+    // Retrieval. preRetrievedChunks (speculative retrieval fired during live
+    // STT) skips the search entirely — the chunks flow into the identical
+    // prompt construction below, so citations/safety behaviour is unchanged.
+    // Retrieval failure (timeout, Supabase outage) degrades to a zero-chunk
+    // answer instead of killing the turn — buildUserContent sends the bare
+    // question and the v2 prompt's no-passage rules take over.
     const ragStart = Date.now();
-    const chunks = await this.search(userMessage, TOP_K);
+    let chunks = [];
+    if (preRetrievedChunks) {
+      chunks = preRetrievedChunks;
+    } else {
+      try {
+        chunks = await this.search(userMessage, TOP_K);
+      } catch (err) {
+        console.warn(`[RAG] retrieval failed (${err.message ?? err}) — answering without passages`);
+      }
+    }
     timingCbs?.onRagDone?.();
-    recordRetrieval({ queryLength: userMessage.length, retrieved: chunks, ragMs: Date.now() - ragStart, path: 'voice' });
+    recordRetrieval({
+      queryLength: userMessage.length,
+      retrieved: chunks,
+      ragMs: Date.now() - ragStart,
+      path: preRetrievedChunks ? 'voice-speculative' : 'voice',
+    });
     const userContent = buildUserContent(userMessage, chunks);
 
     const recentHistory = conversationHistory.slice(-MAX_HISTORY).map(m => ({
@@ -188,7 +239,25 @@ class OpenAIService {
 
     const wake = () => { const n = notify; notify = null; n?.(); };
 
+    // Overall cap plus a time-to-first-byte watchdog: mobile radios can hold a
+    // dead socket open for minutes; 12s with zero bytes means the turn is lost.
+    xhr.timeout = LLM_TOTAL_TIMEOUT_MS;
+    xhr.ontimeout = () => {
+      streamError = streamError ?? new Error('OpenAI stream timed out');
+      finished = true;
+      wake();
+    };
+    let ttfbTimer = setTimeout(() => {
+      ttfbTimer = null;
+      streamError = new Error('OpenAI stream timed out waiting for first response');
+      finished = true;
+      try { xhr.abort(); } catch {}
+      wake();
+    }, LLM_TTFB_TIMEOUT_MS);
+    const clearTtfb = () => { if (ttfbTimer) { clearTimeout(ttfbTimer); ttfbTimer = null; } };
+
     xhr.onprogress = () => {
+      clearTtfb();
       const raw = xhr.responseText.slice(cursor);
       cursor = xhr.responseText.length;
       for (const line of raw.split('\n')) {
@@ -205,6 +274,7 @@ class OpenAIService {
     };
 
     xhr.onload = () => {
+      clearTtfb();
       if (xhr.status === 401) streamError = new OpenAIAuthError('Invalid API key');
       else if (xhr.status === 429) streamError = new OpenAIRateLimitError('Rate limit reached');
       else if (xhr.status >= 400) streamError = new Error(`OpenAI error: HTTP ${xhr.status}`);
@@ -213,7 +283,8 @@ class OpenAIService {
     };
 
     xhr.onerror = () => {
-      streamError = new Error('XHR stream failed');
+      clearTtfb();
+      streamError = streamError ?? new Error('XHR stream failed');
       finished = true;
       wake();
     };
@@ -293,11 +364,22 @@ class OpenAIService {
     formData.append('model', 'whisper-1');
     formData.append('language', 'en');
 
-    const resp = await fetch(`${OPENAI_BASE}/audio/transcriptions`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${apiKey}` },
-      body: formData,
-    });
+    const t = timeoutSignal(WHISPER_TIMEOUT_MS);
+    let resp;
+    try {
+      resp = await fetch(`${OPENAI_BASE}/audio/transcriptions`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: formData,
+        signal: t.signal,
+      });
+    } catch (err) {
+      throw /abort/i.test(err?.message ?? '') || err?.name === 'AbortError'
+        ? new Error('Transcription timed out — please check your connection and try again')
+        : err;
+    } finally {
+      t.cancel();
+    }
 
     if (resp.status === 401) throw new OpenAIAuthError('Invalid API key');
     if (resp.status === 429) throw new OpenAIRateLimitError('Rate limit reached');

--- a/src/lib/rag/speculativeRetrieval.js
+++ b/src/lib/rag/speculativeRetrieval.js
@@ -1,0 +1,119 @@
+// Speculative RAG: start retrieval on a stabilized live-STT partial WHILE the
+// user is still talking, so the embedding + vector-search round trips are done
+// (or in flight) by the time the final transcript arrives.
+//
+// Reuse is decided LEXICALLY (token Jaccard / prefix growth), not by embedding
+// similarity — an embedding comparison would itself cost the round trip we're
+// saving, and since the speculative query and the final transcript come from
+// the same utterance, token overlap is a faithful proxy. Retrieval is
+// chunk-level and robust to a trailing clause.
+//
+// The retrieved chunks flow into the EXACT same prompt construction
+// (buildUserContent / citations) via chatStream's preRetrievedChunks option —
+// safety and citation behaviour are byte-identical to a normal turn.
+
+import {
+  SPECULATIVE_STABLE_MS,
+  SPECULATIVE_MIN_WORDS,
+  SPECULATIVE_MAX_FIRES,
+  SPECULATIVE_REUSE_JACCARD,
+} from '@/lib/voice/voiceConfig';
+
+const tokenize = (text) =>
+  text.toLowerCase().replace(/[^\w\s']/g, ' ').split(/\s+/).filter(Boolean);
+
+function jaccard(tokensA, tokensB) {
+  if (!tokensA.length || !tokensB.length) return 0;
+  const a = new Set(tokensA);
+  const b = new Set(tokensB);
+  let intersection = 0;
+  for (const t of a) if (b.has(t)) intersection++;
+  return intersection / (a.size + b.size - intersection);
+}
+
+/** Speculative text still "covers" the final if it's a token-prefix that grew ≤25%. */
+function isPrefixWithinGrowth(specText, finalText) {
+  const spec = tokenize(specText);
+  const fin = tokenize(finalText);
+  if (!spec.length || spec.length > fin.length) return false;
+  for (let i = 0; i < spec.length; i++) {
+    if (spec[i] !== fin[i]) return false;
+  }
+  return finalText.length <= specText.length * 1.25;
+}
+
+/**
+ * @param {{ search: (query: string) => Promise<Array> }} deps
+ *   search — bound retrieval function (openaiService.search). Its own
+ *   timeouts (embed 5s / RPC 4s) bound the cost of a wasted fire.
+ */
+export function createSpeculativeRag({ search }) {
+  let cancelled = false;
+  let fires = 0;
+  let timer = null;
+  let lastText = '';
+  let current = null; // { queryText, promise } — promise resolves to chunks|null
+
+  const clearTimer = () => { if (timer) { clearTimeout(timer); timer = null; } };
+
+  const fire = (text) => {
+    if (cancelled || fires >= SPECULATIVE_MAX_FIRES) return;
+    // Don't refire when the stabilized text is still close to the in-flight
+    // query — the existing result will pass the reuse gate anyway.
+    if (current && jaccard(tokenize(current.queryText), tokenize(text)) >= SPECULATIVE_REUSE_JACCARD) return;
+    fires++;
+    const startedAt = Date.now();
+    current = {
+      queryText: text,
+      promise: search(text)
+        .then((chunks) => {
+          console.log(`[RAG] speculative fire #${fires} done ms=${Date.now() - startedAt} chunks=${chunks?.length ?? 0}`);
+          return chunks;
+        })
+        .catch((err) => {
+          console.warn(`[RAG] speculative fire failed: ${err?.message ?? err}`);
+          return null; // a failed fire is just a miss
+        }),
+    };
+  };
+
+  return {
+    /** Feed every live-STT partial. Fires after the text stops changing. */
+    onPartial(text) {
+      if (cancelled || !text || text === lastText) return;
+      lastText = text;
+      clearTimer();
+      if (tokenize(text).length < SPECULATIVE_MIN_WORDS) return;
+      timer = setTimeout(() => fire(lastText), SPECULATIVE_STABLE_MS);
+    },
+
+    /**
+     * Decide reuse against the final transcript.
+     * @returns {Promise<{ chunks: Array|null, status: 'hit'|'miss'|'none' }>}
+     *   chunks is null unless status === 'hit'.
+     */
+    async resolve(finalText) {
+      clearTimer();
+      if (cancelled || !current) return { chunks: null, status: 'none' };
+      const specTokens = tokenize(current.queryText);
+      const finalTokens = tokenize(finalText);
+      const overlap = jaccard(specTokens, finalTokens);
+      const reusable =
+        overlap >= SPECULATIVE_REUSE_JACCARD || isPrefixWithinGrowth(current.queryText, finalText);
+      if (!reusable) {
+        console.log(`[RAG] speculative miss (jaccard=${overlap.toFixed(2)})`);
+        return { chunks: null, status: 'miss' };
+      }
+      const chunks = await current.promise;
+      if (!chunks) return { chunks: null, status: 'miss' };
+      console.log(`[RAG] speculative hit (jaccard=${overlap.toFixed(2)}) — retrieval off the hot path`);
+      return { chunks, status: 'hit' };
+    },
+
+    cancel() {
+      cancelled = true;
+      clearTimer();
+      current = null;
+    },
+  };
+}

--- a/src/lib/rag/speculativeRetrieval.test.js
+++ b/src/lib/rag/speculativeRetrieval.test.js
@@ -1,0 +1,107 @@
+import { createSpeculativeRag } from './speculativeRetrieval';
+import { SPECULATIVE_STABLE_MS } from '@/lib/voice/voiceConfig';
+
+const CHUNKS = [{ id: 'c1', title: 'Sundowning basics' }];
+
+// Fake-timer-safe microtask drain (setTimeout would never fire here).
+const flushPromises = async () => { await Promise.resolve(); await Promise.resolve(); };
+
+describe('createSpeculativeRag', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  async function stabilize(spec, text) {
+    spec.onPartial(text);
+    jest.advanceTimersByTime(SPECULATIVE_STABLE_MS + 10);
+  }
+
+  it('fires retrieval after a partial stabilizes and reuses it on a matching final', async () => {
+    const search = jest.fn().mockResolvedValue(CHUNKS);
+    const spec = createSpeculativeRag({ search });
+
+    await stabilize(spec, 'how do I manage sundowning in the evening');
+    expect(search).toHaveBeenCalledTimes(1);
+
+    const result = await spec.resolve('how do I manage sundowning in the evening');
+    expect(result.status).toBe('hit');
+    expect(result.chunks).toBe(CHUNKS);
+  });
+
+  it('reuses when the final only appends a short tail (prefix growth ≤ 25%)', async () => {
+    const search = jest.fn().mockResolvedValue(CHUNKS);
+    const spec = createSpeculativeRag({ search });
+
+    await stabilize(spec, 'what should I do when mum gets agitated at night and will not settle');
+    const result = await spec.resolve('what should I do when mum gets agitated at night and will not settle down');
+    expect(result.status).toBe('hit');
+  });
+
+  it('misses when the final transcript diverges materially', async () => {
+    const search = jest.fn().mockResolvedValue(CHUNKS);
+    const spec = createSpeculativeRag({ search });
+
+    await stabilize(spec, 'tell me about medication reminders');
+    const result = await spec.resolve('actually can you explain respite care options in Auckland');
+    expect(result.status).toBe('miss');
+    expect(result.chunks).toBeNull();
+  });
+
+  it('does not fire on short fragments', async () => {
+    const search = jest.fn().mockResolvedValue(CHUNKS);
+    const spec = createSpeculativeRag({ search });
+
+    await stabilize(spec, 'how do'); // < SPECULATIVE_MIN_WORDS
+    expect(search).not.toHaveBeenCalled();
+    expect((await spec.resolve('how do I help')).status).toBe('none');
+  });
+
+  it('restarts the stabilization window while the partial keeps changing', async () => {
+    const search = jest.fn().mockResolvedValue(CHUNKS);
+    const spec = createSpeculativeRag({ search });
+
+    spec.onPartial('how do I manage sundowning');
+    jest.advanceTimersByTime(SPECULATIVE_STABLE_MS - 100);
+    spec.onPartial('how do I manage sundowning behaviour'); // change resets timer
+    jest.advanceTimersByTime(SPECULATIVE_STABLE_MS - 100);
+    expect(search).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(200);
+    expect(search).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps speculative fires and skips refires for near-identical text', async () => {
+    const search = jest.fn().mockResolvedValue(CHUNKS);
+    const spec = createSpeculativeRag({ search });
+
+    await stabilize(spec, 'first question about morning routines and structure');
+    // Near-identical stabilization → no refire (existing result will pass the gate).
+    await stabilize(spec, 'first question about morning routines and structure please');
+    expect(search).toHaveBeenCalledTimes(1);
+    // Genuinely different → second (and last allowed) fire.
+    await stabilize(spec, 'completely different topic entirely about driving safety assessments');
+    expect(search).toHaveBeenCalledTimes(2);
+    // Third fire is over the cap.
+    await stabilize(spec, 'yet another brand new subject regarding legal power of attorney');
+    expect(search).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a failed search as a miss instead of throwing', async () => {
+    const search = jest.fn().mockRejectedValue(new Error('network down'));
+    const spec = createSpeculativeRag({ search });
+
+    await stabilize(spec, 'how do I manage sundowning in the evening');
+    await flushPromises();
+    const result = await spec.resolve('how do I manage sundowning in the evening');
+    expect(result.status).toBe('miss');
+  });
+
+  it('cancel() prevents firing and resolving', async () => {
+    const search = jest.fn().mockResolvedValue(CHUNKS);
+    const spec = createSpeculativeRag({ search });
+
+    spec.onPartial('how do I manage sundowning in the evening');
+    spec.cancel();
+    jest.advanceTimersByTime(SPECULATIVE_STABLE_MS + 10);
+    expect(search).not.toHaveBeenCalled();
+    expect((await spec.resolve('how do I manage sundowning')).status).toBe('none');
+  });
+});

--- a/src/lib/stt/expoSpeechRecognition.js
+++ b/src/lib/stt/expoSpeechRecognition.js
@@ -14,6 +14,7 @@
 //   AVAudioEngine tap contend for the shared AVAudioSession on iOS.
 
 import { ExpoSpeechRecognitionModule } from 'expo-speech-recognition';
+import { Audio } from 'expo-av';
 import {
   STT_FINAL_TIMEOUT_MS,
   HANDS_FREE_SILENCE_MS,
@@ -21,6 +22,17 @@ import {
   HANDS_FREE_VOLUME_THRESHOLD,
   HANDS_FREE_VOLUME_INTERVAL_MS,
 } from '@/lib/voice/voiceConfig';
+
+// Recognition runs under playAndRecord + measurement (see start() below),
+// which iOS plays MUCH quieter through the speaker — and the category
+// outlives the session. Hand the session back to plain playback as soon as
+// recognition finishes so the avatar's TTS comes out at full volume.
+function restorePlaybackSession() {
+  Audio.setAudioModeAsync({
+    allowsRecordingIOS: false,
+    playsInSilentModeIOS: true,
+  }).catch(() => {});
+}
 
 export function isLiveRecognitionAvailable() {
   try {
@@ -83,6 +95,7 @@ export async function startLiveSession({ handsFree = false, onPartial, onEndOfSp
     const r = stopResolve;
     stopResolve = null;
     cleanup();
+    restorePlaybackSession();
     r(lastTranscript.trim());
   };
 
@@ -187,6 +200,7 @@ export async function startLiveSession({ handsFree = false, onPartial, onEndOfSp
       stopping = true;
       if (gotFinal || ended) {
         cleanup();
+        restorePlaybackSession();
         resolve(lastTranscript.trim());
         return;
       }
@@ -204,6 +218,7 @@ export async function startLiveSession({ handsFree = false, onPartial, onEndOfSp
       settled = true; // block any pending settle from resolving after cancel
       cleanup();
       try { ExpoSpeechRecognitionModule.abort(); } catch {}
+      restorePlaybackSession();
     },
   };
 }

--- a/src/lib/stt/expoSpeechRecognition.js
+++ b/src/lib/stt/expoSpeechRecognition.js
@@ -1,0 +1,200 @@
+// Live (streaming) speech recognition via expo-speech-recognition —
+// iOS SFSpeechRecognizer / Android SpeechRecognizer.
+//
+// Partials arrive WHILE the user is talking, so the transcript is essentially
+// ready the moment they stop — no post-stop Whisper upload round trip.
+//
+// Design notes:
+// - `continuous: true` on both platforms: the OS must never auto-kill the
+//   session mid-utterance in push-to-talk mode; endpointing is ours.
+// - `recordingOptions.persist` keeps the raw audio so the caller can rescue a
+//   failed/empty live transcript by sending the file to Whisper.
+// - The recognition session is the ONLY mic owner per turn. Do not run an
+//   expo-av recording in parallel — AVAudioRecorder and SFSpeechRecognizer's
+//   AVAudioEngine tap contend for the shared AVAudioSession on iOS.
+
+import { ExpoSpeechRecognitionModule } from 'expo-speech-recognition';
+import {
+  STT_FINAL_TIMEOUT_MS,
+  HANDS_FREE_SILENCE_MS,
+  HANDS_FREE_MAX_LEAD_SILENCE_MS,
+  HANDS_FREE_VOLUME_THRESHOLD,
+  HANDS_FREE_VOLUME_INTERVAL_MS,
+} from '@/lib/voice/voiceConfig';
+
+export function isLiveRecognitionAvailable() {
+  try {
+    return ExpoSpeechRecognitionModule.isRecognitionAvailable();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start a live recognition session.
+ *
+ * @param {object} opts
+ * @param {boolean}  opts.handsFree     enable silence auto-endpointing
+ * @param {function} opts.onPartial     (text, { isFinal }) — every transcript update
+ * @param {function} opts.onEndOfSpeech ({ reason }) — hands-free endpoint detected (fires once)
+ * @param {function} opts.onError       (err) — mid-session recognition error
+ *
+ * @returns {Promise<{
+ *   provider: 'live',
+ *   stop: () => Promise<string>,   // finalize; resolves transcript ('' if none)
+ *   cancel: () => void,            // abort, no result
+ *   getRecordedUri: () => string|null, // persisted audio for Whisper rescue
+ * }>}
+ */
+export async function startLiveSession({ handsFree = false, onPartial, onEndOfSpeech, onError } = {}) {
+  const perm = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
+  if (!perm.granted) {
+    const err = new Error('Speech recognition permission not granted');
+    err.code = 'permission-denied';
+    throw err;
+  }
+
+  let lastTranscript = '';
+  let recordedUri = null;
+  let gotFinal = false;
+  let ended = false;
+  let stopping = false;
+  let settled = false;
+  let stopResolve = null;
+  let stopTimer = null;
+  let endpointTimer = null;
+  let endOfSpeechFired = false;
+
+  const subs = [];
+
+  const cleanup = () => {
+    if (stopTimer) { clearTimeout(stopTimer); stopTimer = null; }
+    if (endpointTimer) { clearInterval(endpointTimer); endpointTimer = null; }
+    subs.forEach(s => { try { s.remove(); } catch {} });
+    subs.length = 0;
+  };
+
+  // Resolve the pending stop() with whatever we have. The last interim
+  // transcript is almost always the complete utterance — never block on a
+  // recognizer that won't deliver its final result.
+  const settleStop = () => {
+    if (settled || !stopResolve) return;
+    settled = true;
+    const r = stopResolve;
+    stopResolve = null;
+    cleanup();
+    r(lastTranscript.trim());
+  };
+
+  // Hands-free endpointing state
+  let sawSpeech = false;
+  let lastChangeAt = Date.now();
+  let currentVolume = -2; // library range ≈ -2..10; below 0 is inaudible
+
+  subs.push(ExpoSpeechRecognitionModule.addListener('result', (ev) => {
+    const transcript = ev?.results?.[0]?.transcript ?? '';
+    if (transcript) {
+      if (transcript !== lastTranscript) lastChangeAt = Date.now();
+      lastTranscript = transcript;
+      sawSpeech = true;
+      try { onPartial?.(transcript, { isFinal: !!ev.isFinal }); } catch {}
+    }
+    if (ev?.isFinal) {
+      gotFinal = true;
+      settleStop();
+    }
+  }));
+
+  // The persisted-recording URI arrives on audiostart (iOS) / audioend.
+  subs.push(ExpoSpeechRecognitionModule.addListener('audiostart', (ev) => {
+    if (ev?.uri) recordedUri = ev.uri;
+  }));
+  subs.push(ExpoSpeechRecognitionModule.addListener('audioend', (ev) => {
+    if (ev?.uri) recordedUri = ev.uri;
+  }));
+
+  subs.push(ExpoSpeechRecognitionModule.addListener('end', () => {
+    ended = true;
+    settleStop();
+  }));
+
+  subs.push(ExpoSpeechRecognitionModule.addListener('error', (ev) => {
+    // 'aborted' follows our own abort(); 'no-speech' is an empty utterance,
+    // not a failure — both settle quietly.
+    const code = ev?.error ?? 'unknown';
+    if (code !== 'aborted' && code !== 'no-speech' && !stopping) {
+      try { onError?.(new Error(`Speech recognition error: ${code}${ev?.message ? ` (${ev.message})` : ''}`)); } catch {}
+    }
+    ended = true;
+    settleStop();
+  }));
+
+  if (handsFree) {
+    subs.push(ExpoSpeechRecognitionModule.addListener('volumechange', (ev) => {
+      if (typeof ev?.value === 'number') currentVolume = ev.value;
+    }));
+
+    const startedAt = Date.now();
+    const fireEndOfSpeech = (reason) => {
+      if (endOfSpeechFired || stopping) return;
+      endOfSpeechFired = true;
+      try { onEndOfSpeech?.({ reason }); } catch {}
+    };
+    endpointTimer = setInterval(() => {
+      if (stopping) return;
+      const now = Date.now();
+      if (!sawSpeech) {
+        // Never endpoint on leading silence — but don't listen forever either.
+        if (now - startedAt > HANDS_FREE_MAX_LEAD_SILENCE_MS) fireEndOfSpeech('lead-silence');
+        return;
+      }
+      const quiet = currentVolume < HANDS_FREE_VOLUME_THRESHOLD;
+      const stable = now - lastChangeAt >= HANDS_FREE_SILENCE_MS;
+      if (quiet && stable) fireEndOfSpeech('endpoint');
+    }, HANDS_FREE_VOLUME_INTERVAL_MS);
+  }
+
+  try {
+    ExpoSpeechRecognitionModule.start({
+      lang: 'en-NZ',
+      interimResults: true,
+      continuous: true,
+      requiresOnDeviceRecognition: false,
+      // Keep the raw audio so an empty/failed live transcript can be rescued
+      // by the Whisper fallback (Android 13+/iOS only; null uri elsewhere).
+      recordingOptions: { persist: true },
+      volumeChangeEventOptions: { enabled: handsFree, intervalMillis: HANDS_FREE_VOLUME_INTERVAL_MS },
+    });
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
+
+  return {
+    provider: 'live',
+    getRecordedUri: () => recordedUri,
+
+    stop: () => new Promise((resolve) => {
+      stopping = true;
+      if (gotFinal || ended) {
+        cleanup();
+        resolve(lastTranscript.trim());
+        return;
+      }
+      stopResolve = resolve;
+      stopTimer = setTimeout(settleStop, STT_FINAL_TIMEOUT_MS);
+      try {
+        ExpoSpeechRecognitionModule.stop();
+      } catch {
+        settleStop();
+      }
+    }),
+
+    cancel: () => {
+      stopping = true;
+      settled = true; // block any pending settle from resolving after cancel
+      cleanup();
+      try { ExpoSpeechRecognitionModule.abort(); } catch {}
+    },
+  };
+}

--- a/src/lib/stt/expoSpeechRecognition.js
+++ b/src/lib/stt/expoSpeechRecognition.js
@@ -24,10 +24,19 @@ import {
 } from '@/lib/voice/voiceConfig';
 
 // Recognition runs under playAndRecord + measurement (see start() below),
-// which iOS plays MUCH quieter through the speaker — and the category
-// outlives the session. Hand the session back to plain playback as soon as
-// recognition finishes so the avatar's TTS comes out at full volume.
+// which iOS plays MUCH quieter through the speaker — and BOTH the category
+// and the mode outlive the session (expo-av's setAudioModeAsync resets the
+// category but leaves the session mode untouched, so 'measurement' kept
+// muting playback). Reset category AND mode explicitly, then let expo-av
+// re-sync its own audio-mode state.
 function restorePlaybackSession() {
+  try {
+    ExpoSpeechRecognitionModule.setCategoryIOS({
+      category: 'playback',
+      categoryOptions: [],
+      mode: 'default',
+    });
+  } catch { /* android / older module: nothing to restore */ }
   Audio.setAudioModeAsync({
     allowsRecordingIOS: false,
     playsInSilentModeIOS: true,
@@ -118,9 +127,20 @@ export async function startLiveSession({ handsFree = false, onPartial, onEndOfSp
     }
   }));
 
+  // Resolved when the recognizer confirms its audio tap is open — speech
+  // before this moment is simply lost, so the caller must not show
+  // "listening" until it fires (empty-transcript turns were falling back to
+  // the slow Whisper rescue because users spoke during session spin-up).
+  let audioReadyResolve = null;
+  const audioReady = new Promise((resolve) => { audioReadyResolve = resolve; });
+
   // The persisted-recording URI arrives on audiostart (iOS) / audioend.
   subs.push(ExpoSpeechRecognitionModule.addListener('audiostart', (ev) => {
     if (ev?.uri) recordedUri = ev.uri;
+    if (audioReadyResolve) { const r = audioReadyResolve; audioReadyResolve = null; r(); }
+  }));
+  subs.push(ExpoSpeechRecognitionModule.addListener('start', () => {
+    if (audioReadyResolve) { const r = audioReadyResolve; audioReadyResolve = null; r(); }
   }));
   subs.push(ExpoSpeechRecognitionModule.addListener('audioend', (ev) => {
     if (ev?.uri) recordedUri = ev.uri;
@@ -191,6 +211,13 @@ export async function startLiveSession({ handsFree = false, onPartial, onEndOfSp
     cleanup();
     throw err;
   }
+
+  // Block (briefly) until audio is actually flowing; cap the wait so a
+  // recognizer that never emits 'start' can't hang the mic button.
+  await Promise.race([
+    audioReady,
+    new Promise((resolve) => setTimeout(resolve, 1500)),
+  ]);
 
   return {
     provider: 'live',

--- a/src/lib/stt/expoSpeechRecognition.js
+++ b/src/lib/stt/expoSpeechRecognition.js
@@ -164,6 +164,15 @@ export async function startLiveSession({ handsFree = false, onPartial, onEndOfSp
       // by the Whisper fallback (Android 13+/iOS only; null uri elsewhere).
       recordingOptions: { persist: true },
       volumeChangeEventOptions: { enabled: handsFree, intervalMillis: HANDS_FREE_VOLUME_INTERVAL_MS },
+      // playAndRecord shares the AVAudioSession with the avatar's WebView
+      // playback instead of fighting it — without this, recognition dies at
+      // start with "Audio session was interrupted" whenever the WebView's
+      // AudioContext holds the session.
+      iosCategory: {
+        category: 'playAndRecord',
+        categoryOptions: ['defaultToSpeaker', 'allowBluetooth'],
+        mode: 'measurement',
+      },
     });
   } catch (err) {
     cleanup();

--- a/src/lib/stt/sttService.js
+++ b/src/lib/stt/sttService.js
@@ -1,0 +1,64 @@
+// Provider-agnostic STT facade for the voice pipeline.
+//
+//   const session = await startSttSession({ handsFree, onPartial, onEndOfSpeech, onError });
+//   ...user talks; partials stream via onPartial (live provider only)...
+//   const { transcript, source } = await session.stop();   // or session.cancel()
+//
+// Provider selection per turn:
+//   1. Live recognition (expo-speech-recognition) when the config flag is on,
+//      the device supports it, and no earlier live start has failed this
+//      session (sticky degrade — a device that fails once will keep failing).
+//   2. Whisper file-upload fallback (expo-av) otherwise.
+//
+// Live sessions that finalize to an EMPTY transcript are rescued through
+// Whisper using the recognizer's persisted recording, so a bad recognition
+// day never silently loses the user's words.
+
+import { VOICE_STREAMING_STT } from '@/lib/voice/voiceConfig';
+import { isLiveRecognitionAvailable, startLiveSession } from './expoSpeechRecognition';
+import { startWhisperSession, transcribeFile } from './whisperFallback';
+
+let sttDegraded = false; // sticky for the app session after a live start failure
+
+export async function startSttSession(opts = {}) {
+  if (VOICE_STREAMING_STT && !sttDegraded && isLiveRecognitionAvailable()) {
+    try {
+      const live = await startLiveSession(opts);
+      return wrapLiveSession(live);
+    } catch (err) {
+      if (err?.code === 'permission-denied') throw err; // don't burn the fallback on a denial
+      console.warn(`[STT] live recognition failed to start (${err?.message ?? err}) — using Whisper fallback from now on`);
+      sttDegraded = true;
+    }
+  }
+
+  const whisper = await startWhisperSession();
+  return {
+    provider: whisper.provider,
+    cancel: whisper.cancel,
+    stop: async () => ({ transcript: (await whisper.stop()) ?? '', source: 'whisper' }),
+  };
+}
+
+function wrapLiveSession(live) {
+  return {
+    provider: live.provider,
+    cancel: live.cancel,
+    stop: async () => {
+      const transcript = await live.stop();
+      if (transcript) return { transcript, source: 'live' };
+
+      // Empty live result: rescue via Whisper if the recognizer kept the audio.
+      const uri = live.getRecordedUri();
+      if (uri) {
+        try {
+          const rescued = await transcribeFile(uri);
+          if (rescued) return { transcript: rescued, source: 'whisper-rescue' };
+        } catch (err) {
+          console.warn(`[STT] whisper rescue failed: ${err?.message ?? err}`);
+        }
+      }
+      return { transcript: '', source: 'live' };
+    },
+  };
+}

--- a/src/lib/stt/whisperFallback.js
+++ b/src/lib/stt/whisperFallback.js
@@ -1,0 +1,94 @@
+// Legacy STT path: expo-av records the full utterance, then the file is
+// uploaded to Whisper. This is the code that used to live inside
+// useAvatarConversation — kept behaviour-identical as the fallback for when
+// live recognition is unavailable (no permission, unsupported device,
+// VOICE_STREAMING_STT off, or a live-session start failure).
+
+import { Audio } from 'expo-av';
+import * as FileSystem from 'expo-file-system/legacy';
+import { openaiService } from '@/lib/openaiService';
+
+// Whisper-optimised recording: 16 kHz mono reduces upload size ~4× vs HIGH_QUALITY
+// with no accuracy loss (Whisper resamples to 16 kHz internally).
+export const WHISPER_RECORDING_OPTIONS = {
+  isMeteringEnabled: false,
+  android: {
+    extension: '.m4a',
+    outputFormat: Audio.AndroidOutputFormat.MPEG_4,
+    audioEncoder: Audio.AndroidAudioEncoder.AAC,
+    sampleRate: 16000,
+    numberOfChannels: 1,
+    bitRate: 32000,
+  },
+  ios: {
+    extension: '.m4a',
+    outputFormat: Audio.IOSOutputFormat.MPEG4AAC,
+    audioQuality: Audio.IOSAudioQuality.LOW,
+    sampleRate: 16000,
+    numberOfChannels: 1,
+    bitRate: 32000,
+    linearPCMBitDepth: 16,
+    linearPCMIsBigEndian: false,
+    linearPCMIsFloat: false,
+  },
+};
+
+/** Transcribe an existing audio file (also used to rescue empty live sessions). */
+export function transcribeFile(uri) {
+  return openaiService.transcribe(uri);
+}
+
+/**
+ * Start a Whisper-backed recording session with the same interface as the
+ * live session in expoSpeechRecognition.js. No partials, no hands-free
+ * endpointing (there is no signal to endpoint on without the recognizer).
+ */
+export async function startWhisperSession() {
+  const { status } = await Audio.requestPermissionsAsync();
+  if (status !== 'granted') {
+    const err = new Error('Microphone permission not granted');
+    err.code = 'permission-denied';
+    throw err;
+  }
+
+  await Audio.setAudioModeAsync({
+    allowsRecordingIOS: true,
+    playsInSilentModeIOS: true,
+  });
+
+  let recording;
+  try {
+    ({ recording } = await Audio.Recording.createAsync(WHISPER_RECORDING_OPTIONS));
+  } catch (err) {
+    await Audio.setAudioModeAsync({ allowsRecordingIOS: false }).catch(() => {});
+    throw err;
+  }
+
+  let done = false;
+
+  return {
+    provider: 'whisper',
+    getRecordedUri: () => null, // stop() already ran Whisper on the recording
+
+    stop: async () => {
+      if (done) return '';
+      done = true;
+      await recording.stopAndUnloadAsync();
+      const uri = recording.getURI();
+      await Audio.setAudioModeAsync({
+        allowsRecordingIOS: false,
+        playsInSilentModeIOS: true,
+      });
+      const transcript = await transcribeFile(uri);
+      FileSystem.deleteAsync(uri, { idempotent: true }).catch(() => {});
+      return transcript ?? '';
+    },
+
+    cancel: () => {
+      if (done) return;
+      done = true;
+      recording.stopAndUnloadAsync().catch(() => {});
+      Audio.setAudioModeAsync({ allowsRecordingIOS: false }).catch(() => {});
+    },
+  };
+}

--- a/src/lib/tts/elevenLabsService.js
+++ b/src/lib/tts/elevenLabsService.js
@@ -1,8 +1,10 @@
 import * as SecureStore from 'expo-secure-store';
 import { createVisemeTimeline } from '@/lib/lipsync/createVisemeTimeline';
+import { timeoutSignal } from '@/lib/net/withTimeout';
 
 const ELEVENLABS_BASE = 'https://api.elevenlabs.io';
 const SECURE_KEY_NAME = 'elevenlabs_api_key';
+const REQUEST_TIMEOUT_MS = 10000; // whole-sentence synthesis; a hung call stalls the play queue
 
 // eleven_turbo_v2_5 is the low-latency model — best choice for real-time conversation.
 // Swap to 'eleven_multilingual_v2' for higher quality at the cost of ~300 ms extra latency.
@@ -68,27 +70,34 @@ class ElevenLabsService {
     const apiKey = await this.getApiKey();
     if (!apiKey) throw new ElevenLabsAuthError('No ElevenLabs API key configured');
 
-    const resp = await fetch(
-      `${ELEVENLABS_BASE}/v1/text-to-speech/${encodeURIComponent(voiceId)}/with-timestamps`,
-      {
-        method: 'POST',
-        headers: {
-          'xi-api-key': apiKey,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          text,
-          model_id: DEFAULT_MODEL_ID,
-          output_format: 'mp3_44100_64',
-          voice_settings: {
-            stability: 0.40,
-            similarity_boost: 0.75,
-            style: 0.20,
-            speed: speechRate,
+    const t = timeoutSignal(REQUEST_TIMEOUT_MS);
+    let resp;
+    try {
+      resp = await fetch(
+        `${ELEVENLABS_BASE}/v1/text-to-speech/${encodeURIComponent(voiceId)}/with-timestamps`,
+        {
+          method: 'POST',
+          headers: {
+            'xi-api-key': apiKey,
+            'Content-Type': 'application/json',
           },
-        }),
-      }
-    );
+          body: JSON.stringify({
+            text,
+            model_id: DEFAULT_MODEL_ID,
+            output_format: 'mp3_44100_64',
+            voice_settings: {
+              stability: 0.40,
+              similarity_boost: 0.75,
+              style: 0.20,
+              speed: speechRate,
+            },
+          }),
+          signal: t.signal,
+        }
+      );
+    } finally {
+      t.cancel();
+    }
 
     if (resp.status === 401) throw new ElevenLabsAuthError('Invalid ElevenLabs API key');
     if (resp.status === 429) throw new ElevenLabsRateLimitError('ElevenLabs rate limit reached');

--- a/src/lib/tts/elevenLabsStreamService.js
+++ b/src/lib/tts/elevenLabsStreamService.js
@@ -1,0 +1,294 @@
+// ElevenLabs WebSocket streaming TTS — one session per response turn.
+//
+// Why: the REST /with-timestamps path blocks until a WHOLE sentence is
+// synthesized (~400–1200 ms before any audio). The stream-input WebSocket
+// accepts text incrementally (LLM tokens forwarded as they arrive) and
+// returns audio chunks WITH per-chunk character alignment, so first audio
+// lands in ~100–250 ms and the viseme lip-sync pipeline keeps working.
+//
+// Lifecycle (driven by useAvatarConversation's streaming producer):
+//   const s = createElevenLabsStream({...});
+//   await s.open();          // fire in parallel with the LLM request — WS
+//                            // setup (~200-300 ms) hides inside LLM TTFT
+//   s.sendText(token);       // every LLM token, as it arrives
+//   s.flush();               // at sentence boundaries (clean prosody breaks)
+//   s.end();                 // LLM done — close input, remaining audio drains
+//   s.abort();               // barge-in — drop everything now
+//
+// Failure contract: onError fires ONCE on any fatal condition (open timeout,
+// socket error, audio stall). The caller falls back to the REST cascade and
+// replays unspoken sentences — worst case equals the pre-streaming pipeline.
+
+import {
+  ELEVEN_STREAM_MODEL,
+  ELEVEN_STREAM_FORMAT,
+  ELEVEN_STREAM_SAMPLE_RATE,
+  ELEVEN_CHUNK_SCHEDULE,
+  WS_OPEN_TIMEOUT_MS,
+  WS_STALL_TIMEOUT_MS,
+} from '@/lib/voice/voiceConfig';
+import { normalizeSpokenText } from './normalizeSpokenText';
+
+const ELEVENLABS_WS_BASE = 'wss://api.elevenlabs.io';
+
+/** Duration in seconds of a base64-encoded 16-bit mono PCM payload. */
+export function pcmBase64DurationSec(b64, sampleRate = ELEVEN_STREAM_SAMPLE_RATE) {
+  if (!b64) return 0;
+  const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0;
+  const bytes = Math.floor((b64.length * 3) / 4) - padding;
+  return bytes / 2 / sampleRate;
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.apiKey
+ * @param {string} opts.voiceId
+ * @param {string} [opts.modelId]
+ * @param {number} [opts.speechRate]
+ * @param {function} opts.onAudioChunk ({ pcmBase64, durationSec, alignment, chunkIndex })
+ *   alignment = { chars, charStartTimesMs, charDurationsMs } | null
+ * @param {function} opts.onFinal    () — server confirmed end of stream
+ * @param {function} opts.onError    (err) — fatal; fires at most once
+ * @param {function} [opts.onTextSent] (text) — exactly what went over the wire
+ *   (post-normalization, including the BOS space). Cumulative length matches
+ *   the alignment char stream — the join key for subtitle timing.
+ */
+export function createElevenLabsStream({
+  apiKey,
+  voiceId,
+  modelId = ELEVEN_STREAM_MODEL,
+  speechRate = 0.78,
+  onAudioChunk,
+  onFinal,
+  onError,
+  onTextSent,
+}) {
+  let ws = null;
+  let openPromise = null;
+  let wsOpen = false;
+  let dead = false;          // fatal error or abort — ignore everything after
+  let inputEnded = false;    // end() called
+  let finalReceived = false; // server isFinal seen
+  let chunkIndex = 0;
+  let stallTimer = null;
+  let errorFired = false;
+
+  // Text queued before the socket finished opening (open() runs concurrently
+  // with the LLM request, so early tokens can beat the handshake).
+  const preOpenQueue = [];
+
+  // ElevenLabs buffers text server-side; each message should end cleanly on a
+  // word boundary for best quality, so we forward whole words and hold the
+  // trailing partial word until the next token completes it. Word-level
+  // normalizeSpokenText is equivalent to the REST path's sentence-level pass
+  // (all its patterns are word-bounded) and keeps digits animating the lips.
+  let wordBuf = '';
+
+  const fireError = (err) => {
+    if (errorFired || dead) return;
+    errorFired = true;
+    dead = true;
+    clearStall();
+    try { ws?.close(); } catch {}
+    try { onError?.(err); } catch {}
+  };
+
+  const clearStall = () => {
+    if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
+  };
+
+  // Audio must keep arriving while we have undelivered input. Re-armed on
+  // every send and every received chunk; disarmed once the server finalizes.
+  const armStall = () => {
+    clearStall();
+    if (dead || finalReceived) return;
+    stallTimer = setTimeout(() => {
+      fireError(new Error(`ElevenLabs stream stalled (no audio for ${WS_STALL_TIMEOUT_MS}ms)`));
+    }, WS_STALL_TIMEOUT_MS);
+  };
+
+  const wsSend = (obj) => {
+    if (dead) return false;
+    if (!wsOpen) {
+      preOpenQueue.push(obj);
+      return true; // will flush on open; open-timeout catches a dead handshake
+    }
+    try {
+      ws.send(JSON.stringify(obj));
+      return true;
+    } catch (err) {
+      fireError(err);
+      return false;
+    }
+  };
+
+  const sendTextPayload = (text, flush = false) => {
+    if (!text && !flush) return false;
+    const ok = wsSend(flush ? { text, flush: true } : { text });
+    if (ok && text) { try { onTextSent?.(text); } catch {} }
+    return ok;
+  };
+
+  const open = () => {
+    if (openPromise) return openPromise;
+    openPromise = new Promise((resolve, reject) => {
+      const url =
+        `${ELEVENLABS_WS_BASE}/v1/text-to-speech/${encodeURIComponent(voiceId)}/stream-input` +
+        `?model_id=${encodeURIComponent(modelId)}` +
+        `&output_format=${encodeURIComponent(ELEVEN_STREAM_FORMAT)}` +
+        `&auto_mode=false&inactivity_timeout=60`;
+
+      let settled = false;
+      const openTimer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        dead = true;
+        try { ws?.close(); } catch {}
+        reject(new Error(`ElevenLabs WS open timed out after ${WS_OPEN_TIMEOUT_MS}ms`));
+      }, WS_OPEN_TIMEOUT_MS);
+
+      try {
+        ws = new WebSocket(url);
+      } catch (err) {
+        clearTimeout(openTimer);
+        settled = true;
+        reject(err);
+        return;
+      }
+
+      ws.onopen = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(openTimer);
+        // BOS message: auth + voice/generation config. xi_api_key in-message
+        // avoids relying on RN WebSocket header support.
+        try {
+          ws.send(JSON.stringify({
+            text: ' ',
+            voice_settings: {
+              stability: 0.40,
+              similarity_boost: 0.75,
+              style: 0.20,
+              speed: speechRate,
+            },
+            generation_config: { chunk_length_schedule: ELEVEN_CHUNK_SCHEDULE },
+            xi_api_key: apiKey,
+          }));
+        } catch (err) {
+          reject(err);
+          return;
+        }
+        try { onTextSent?.(' '); } catch {}
+        wsOpen = true;
+        // Flush text that arrived while the handshake was in flight
+        // (onTextSent already fired for these when they were queued).
+        const queued = preOpenQueue.splice(0);
+        for (const obj of queued) {
+          if (!wsSend(obj)) break;
+        }
+        resolve();
+      };
+
+      ws.onmessage = (event) => {
+        if (dead) return;
+        let msg;
+        try { msg = JSON.parse(event.data); } catch { return; }
+
+        if (msg.audio) {
+          armStall();
+          const durationSec = pcmBase64DurationSec(msg.audio);
+          try {
+            onAudioChunk?.({
+              pcmBase64: msg.audio,
+              durationSec,
+              alignment: msg.alignment ?? null,
+              chunkIndex: chunkIndex++,
+            });
+          } catch {}
+        }
+
+        if (msg.isFinal) {
+          finalReceived = true;
+          clearStall();
+          try { onFinal?.(); } catch {}
+          try { ws?.close(); } catch {}
+        }
+
+        if (msg.error) {
+          fireError(new Error(`ElevenLabs stream error: ${msg.message ?? msg.error}`));
+        }
+      };
+
+      ws.onerror = (event) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(openTimer);
+          dead = true;
+          reject(new Error(`ElevenLabs WS connection error${event?.message ? `: ${event.message}` : ''}`));
+          return;
+        }
+        fireError(new Error(`ElevenLabs WS error${event?.message ? `: ${event.message}` : ''}`));
+      };
+
+      ws.onclose = () => {
+        clearStall();
+        // Close without isFinal while input was still pending = fatal.
+        if (!finalReceived && !dead && inputEnded === false) {
+          fireError(new Error('ElevenLabs WS closed unexpectedly'));
+        } else if (!finalReceived && !dead && inputEnded) {
+          // Input ended but server closed without isFinal — treat drained
+          // audio as complete rather than erroring a finished response.
+          finalReceived = true;
+          try { onFinal?.(); } catch {}
+        }
+      };
+    });
+    return openPromise;
+  };
+
+  return {
+    open,
+
+    /** Forward LLM text as it arrives. Whole words only; remainder is held. */
+    sendText(text) {
+      if (dead || inputEnded || !text) return;
+      wordBuf += text;
+      const lastSpace = wordBuf.lastIndexOf(' ');
+      if (lastSpace < 0) return;
+      const sendable = wordBuf.slice(0, lastSpace + 1);
+      wordBuf = wordBuf.slice(lastSpace + 1);
+      if (sendable.trim().length === 0) return;
+      if (sendTextPayload(normalizeSpokenText(sendable))) armStall();
+    },
+
+    /**
+     * Sentence boundary: force generation of the server-side buffer for a
+     * clean prosody break. Deliberately does NOT push the held word — at a
+     * boundary, the held word is the NEXT sentence's first word (LLM output
+     * has a space after ".", so the sentence-final word is always already
+     * sent); pulling it forward would tie it to the wrong generation.
+     */
+    flush() {
+      if (dead || inputEnded) return;
+      if (sendTextPayload(' ', true)) armStall();
+    },
+
+    /** LLM done: send EOS; remaining audio + isFinal will drain. */
+    end() {
+      if (dead || inputEnded) return;
+      if (wordBuf.trim()) sendTextPayload(`${normalizeSpokenText(wordBuf)} `, true);
+      wordBuf = '';
+      inputEnded = true;
+      if (wsSend({ text: '' })) armStall();
+    },
+
+    /** Barge-in / teardown: drop everything immediately, no callbacks. */
+    abort() {
+      dead = true;
+      clearStall();
+      try { ws?.close(); } catch {}
+    },
+
+    get isDead() { return dead; },
+  };
+}

--- a/src/lib/tts/elevenLabsStreamService.test.js
+++ b/src/lib/tts/elevenLabsStreamService.test.js
@@ -1,0 +1,197 @@
+/* global Buffer */
+import { createElevenLabsStream, pcmBase64DurationSec } from './elevenLabsStreamService';
+
+// Minimal WebSocket fake: captures sent payloads, lets tests drive open/message.
+class FakeWebSocket {
+  static instances = [];
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0;
+    this.sent = [];
+    FakeWebSocket.instances.push(this);
+  }
+  send(data) { this.sent.push(JSON.parse(data)); }
+  close() { this.readyState = 3; this.onclose?.({}); }
+  emitOpen() { this.readyState = 1; this.onopen?.(); }
+  emitMessage(obj) { this.onmessage?.({ data: JSON.stringify(obj) }); }
+}
+
+describe('pcmBase64DurationSec', () => {
+  it('computes duration from 16-bit mono byte length', () => {
+    // 22050 samples = 1s = 44100 bytes → base64 length 58800.
+    const bytes = new Uint8Array(44100);
+    const b64 = Buffer.from(bytes).toString('base64');
+    expect(pcmBase64DurationSec(b64, 22050)).toBeCloseTo(1.0, 3);
+  });
+  it('returns 0 for empty payloads', () => {
+    expect(pcmBase64DurationSec('')).toBe(0);
+  });
+});
+
+describe('createElevenLabsStream', () => {
+  const realWebSocket = global.WebSocket;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    FakeWebSocket.instances = [];
+    global.WebSocket = FakeWebSocket;
+  });
+  afterEach(() => {
+    global.WebSocket = realWebSocket;
+    jest.useRealTimers();
+  });
+
+  function makeStream(overrides = {}) {
+    const events = { chunks: [], final: 0, errors: [], sentText: [] };
+    const stream = createElevenLabsStream({
+      apiKey: 'k',
+      voiceId: 'voice123',
+      onAudioChunk: (c) => events.chunks.push(c),
+      onFinal: () => events.final++,
+      onError: (e) => events.errors.push(e),
+      onTextSent: (t) => events.sentText.push(t),
+      ...overrides,
+    });
+    return { stream, events };
+  }
+
+  it('sends BOS config on open and forwards whole words only', () => {
+    const { stream, events } = makeStream();
+    stream.open();
+    const ws = FakeWebSocket.instances[0];
+    ws.emitOpen();
+
+    expect(ws.sent[0].xi_api_key).toBe('k');
+    expect(ws.sent[0].voice_settings.speed).toBe(0.78);
+
+    stream.sendText('Hello wor');
+    // 'Hello ' sent; 'wor' held until the word completes.
+    expect(ws.sent[1]).toEqual({ text: 'Hello ' });
+    stream.sendText('ld. Next');
+    expect(ws.sent[2]).toEqual({ text: 'world. ' });
+    // onTextSent mirrors the wire exactly (BOS space + both text sends).
+    expect(events.sentText).toEqual([' ', 'Hello ', 'world. ']);
+  });
+
+  it('queues text sent before the handshake completes', () => {
+    const { stream } = makeStream();
+    stream.open();
+    stream.sendText('Early tokens here ');
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.sent).toHaveLength(0); // nothing on the wire yet
+    ws.emitOpen();
+    expect(ws.sent[0].xi_api_key).toBe('k'); // BOS first
+    expect(ws.sent[1]).toEqual({ text: 'Early tokens here ' });
+  });
+
+  it('normalizes numbers at the word level so alignment gets real letters', () => {
+    const { stream } = makeStream();
+    stream.open();
+    FakeWebSocket.instances[0].emitOpen();
+    stream.sendText('call 0800 late');
+    const ws = FakeWebSocket.instances[0];
+    // '0800 ' is a complete word → normalized like the REST path would.
+    expect(ws.sent[1].text).toBe('call eight hundred ');
+  });
+
+  it('flush() forces generation without stealing the next sentence\'s held word', () => {
+    const { stream } = makeStream();
+    stream.open();
+    const ws = FakeWebSocket.instances[0];
+    ws.emitOpen();
+    stream.sendText('First sentence. Next');
+    stream.flush(); // boundary detected by the caller
+    const flushMsg = ws.sent.find((m) => m.flush);
+    expect(flushMsg).toEqual({ text: ' ', flush: true });
+    // 'Next' is still held for the next sentence.
+    stream.sendText(' words ');
+    expect(ws.sent[ws.sent.length - 1].text).toBe('Next words ');
+  });
+
+  it('end() releases held text then closes input with an empty message', () => {
+    const { stream } = makeStream();
+    stream.open();
+    const ws = FakeWebSocket.instances[0];
+    ws.emitOpen();
+    stream.sendText('Goodbye now.');
+    stream.end();
+    const texts = ws.sent.map((m) => m.text);
+    // 'Goodbye ' went out on sendText; the held 'now.' is released by end().
+    expect(texts.slice(1)).toEqual(['Goodbye ', 'now. ', '']);
+  });
+
+  it('delivers audio chunks with duration and alignment, then final', () => {
+    const { stream, events } = makeStream();
+    stream.open();
+    const ws = FakeWebSocket.instances[0];
+    ws.emitOpen();
+
+    const b64 = Buffer.from(new Uint8Array(4410)).toString('base64'); // 100ms @22050
+    ws.emitMessage({ audio: b64, alignment: { chars: ['h', 'i'], charStartTimesMs: [0, 50], charDurationsMs: [50, 50] } });
+    expect(events.chunks).toHaveLength(1);
+    expect(events.chunks[0].durationSec).toBeCloseTo(0.1, 3);
+    expect(events.chunks[0].alignment.chars).toEqual(['h', 'i']);
+
+    ws.emitMessage({ isFinal: true });
+    expect(events.final).toBe(1);
+    expect(events.errors).toHaveLength(0);
+  });
+
+  it('rejects open() when the handshake times out', async () => {
+    const { stream } = makeStream();
+    const p = stream.open();
+    const assertion = expect(p).rejects.toThrow(/open timed out/);
+    jest.advanceTimersByTime(4000);
+    await assertion;
+  });
+
+  it('fires onError once when the socket stalls with input pending', () => {
+    const { stream, events } = makeStream();
+    stream.open();
+    const ws = FakeWebSocket.instances[0];
+    ws.emitOpen();
+    stream.sendText('Some words here ');
+    jest.advanceTimersByTime(7000); // > WS_STALL_TIMEOUT_MS with no audio
+    expect(events.errors).toHaveLength(1);
+    expect(String(events.errors[0].message)).toMatch(/stalled/);
+    // Further failures don't re-fire.
+    ws.onerror?.({ message: 'later' });
+    expect(events.errors).toHaveLength(1);
+  });
+
+  it('treats an unexpected close mid-input as fatal', () => {
+    const { stream, events } = makeStream();
+    stream.open();
+    const ws = FakeWebSocket.instances[0];
+    ws.emitOpen();
+    stream.sendText('Talking along ');
+    ws.close();
+    expect(events.errors).toHaveLength(1);
+    expect(String(events.errors[0].message)).toMatch(/closed unexpectedly/);
+  });
+
+  it('treats a close after end() as completion, not an error', () => {
+    const { stream, events } = makeStream();
+    stream.open();
+    const ws = FakeWebSocket.instances[0];
+    ws.emitOpen();
+    stream.sendText('All done. ');
+    stream.end();
+    ws.close(); // server closed without an explicit isFinal
+    expect(events.errors).toHaveLength(0);
+    expect(events.final).toBe(1);
+  });
+
+  it('abort() silences all subsequent callbacks', () => {
+    const { stream, events } = makeStream();
+    stream.open();
+    const ws = FakeWebSocket.instances[0];
+    ws.emitOpen();
+    stream.sendText('Interrupt me ');
+    stream.abort();
+    ws.emitMessage({ audio: Buffer.from(new Uint8Array(100)).toString('base64') });
+    ws.emitMessage({ isFinal: true });
+    expect(events.chunks).toHaveLength(0);
+    expect(events.final).toBe(0);
+    expect(events.errors).toHaveLength(0);
+  });
+});

--- a/src/lib/tts/ttsMode.js
+++ b/src/lib/tts/ttsMode.js
@@ -1,0 +1,32 @@
+// Decides per turn whether the voice pipeline uses the ElevenLabs WebSocket
+// streaming path or the classic per-sentence REST cascade.
+//
+// Streaming requires: developer flag on, no sticky degrade this session, an
+// ElevenLabs key, and NO Azure credentials — Azure users keep their
+// higher-fidelity phoneme-viseme REST path (streaming Azure is future work).
+// The caller additionally gates on the renderer's supportsStreamingAudio and
+// the user's fastVoiceMode setting.
+
+import { VOICE_STREAMING_TTS } from '@/lib/voice/voiceConfig';
+import { azureTtsService } from './azureTtsService';
+import { elevenLabsService } from './elevenLabsService';
+
+let ttsDegraded = false; // sticky after a mid-turn WS failure — REST for the rest of the session
+
+export function markTtsDegraded(reason) {
+  if (!ttsDegraded) {
+    console.warn(`[TTS] streaming degraded for this session: ${reason}`);
+  }
+  ttsDegraded = true;
+}
+
+export async function selectTtsMode() {
+  if (!VOICE_STREAMING_TTS || ttsDegraded) return 'rest';
+  try {
+    if (await azureTtsService.hasCredentials()) return 'rest';
+    if (await elevenLabsService.hasApiKey()) return 'eleven-stream';
+  } catch {
+    // credential checks failing → be conservative
+  }
+  return 'rest';
+}

--- a/src/lib/tts/ttsService.ts
+++ b/src/lib/tts/ttsService.ts
@@ -65,15 +65,16 @@ export async function tts(text: string, options: TtsOptions = {}): Promise<TtsRe
 
   const hasElevenLabs = await elevenLabsService.hasApiKey();
   if (hasElevenLabs) {
-    // Avatar profiles carry Azure voice names (e.g. en-US-EricNeural), which are NOT
-    // valid ElevenLabs voice IDs. Only forward a voice that looks like an ElevenLabs
-    // ID (16+ alphanumerics); otherwise use a warm, mature male voice (Brian) that
-    // matches the Aaron avatar, instead of 404-ing or landing on the female default.
+    // Prefer the profile's explicit ElevenLabs voice ID. options.voice carries the
+    // Azure voice name (e.g. en-US-EricNeural), which is NOT a valid ElevenLabs ID —
+    // only forward it if it looks like one (16+ alphanumerics); otherwise fall back
+    // to a warm, mature male voice (Brian) instead of 404-ing.
     const WARM_MALE_ELEVEN_VOICE = 'nPczCjzI2devNBz1zQrb'; // ElevenLabs "Brian"
     const elevenVoice =
-      options.voice && /^[A-Za-z0-9]{16,}$/.test(options.voice)
+      options.elevenVoiceId ??
+      (options.voice && /^[A-Za-z0-9]{16,}$/.test(options.voice)
         ? options.voice
-        : WARM_MALE_ELEVEN_VOICE;
+        : WARM_MALE_ELEVEN_VOICE);
     const t0 = Date.now();
     try {
       const { audioBase64, visemeTimeline } = await elevenLabsService.ttsWithAlignment(
@@ -93,14 +94,15 @@ export async function tts(text: string, options: TtsOptions = {}): Promise<TtsRe
     }
   }
 
-  // OpenAI TTS only accepts its own voice enum. options.voice may be an Azure
-  // (en-US-EricNeural) or ElevenLabs (voice-id) name from the avatar profile, which
-  // OpenAI rejects — so whitelist it and fall back to a valid voice (onyx = male,
-  // matching the current avatar) rather than passing an incompatible name through.
+  // OpenAI TTS only accepts its own voice enum. Prefer the profile's explicit
+  // openaiVoice; options.voice may be an Azure (en-US-EricNeural) or ElevenLabs
+  // (voice-id) name, which OpenAI rejects — whitelist and fall back to onyx.
   const OPENAI_VOICES = new Set([
     'nova', 'shimmer', 'echo', 'onyx', 'fable', 'alloy', 'ash', 'sage', 'coral',
   ]);
-  const openaiVoice = options.voice && OPENAI_VOICES.has(options.voice) ? options.voice : 'onyx';
+  const requestedOpenaiVoice = options.openaiVoice ?? options.voice;
+  const openaiVoice =
+    requestedOpenaiVoice && OPENAI_VOICES.has(requestedOpenaiVoice) ? requestedOpenaiVoice : 'onyx';
   const t0 = Date.now();
   const dataUri = await openaiService.tts(text, openaiVoice);
   // OpenAI returns no alignment, so there is NO lip-sync on this path — the WebView

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,7 +27,12 @@ export interface VisemeTimeline {
 
 export interface TtsOptions {
   speechRate?: number;
+  /** Azure voice name (e.g. en-US-JennyNeural) from the avatar profile. */
   voice?: string | null;
+  /** ElevenLabs voice ID from the avatar profile; falls back to Brian. */
+  elevenVoiceId?: string | null;
+  /** OpenAI voice enum value from the avatar profile; falls back to onyx. */
+  openaiVoice?: string | null;
   visemeWeights?: Record<string, number> | null;
 }
 

--- a/src/lib/voice/prewarm.js
+++ b/src/lib/voice/prewarm.js
@@ -1,0 +1,64 @@
+// Voice-pipeline pre-warm: pay the cold-start costs BEFORE the user speaks.
+//
+// Two real costs get eliminated from the first turn's hot path:
+//   1. SecureStore key reads (10–50 ms each) — cached in each service after
+//      the first call, so touching them here makes the hot-path reads free.
+//   2. TCP+TLS+HTTP/2 handshakes to each API host (100–300 ms per host on
+//      mobile networks) — NSURLSession/OkHttp pool connections per host, so
+//      one tiny request per host warms the pool for the real calls.
+//
+// Deliberately NOT done here: speculative embeddings or retrieval of guessed
+// queries — they cost tokens and buy nothing beyond the connection warmth.
+//
+// All work is fire-and-forget and individually try/caught: pre-warm must
+// never surface an error or delay anything.
+
+import { openaiService } from '@/lib/openaiService';
+import { elevenLabsService } from '@/lib/tts/elevenLabsService';
+import { azureTtsService } from '@/lib/tts/azureTtsService';
+
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+const PREWARM_INTERVAL_MS = 5 * 60 * 1000; // connections idle out well before this
+let lastPrewarmAt = 0;
+
+const swallow = () => {};
+
+export function prewarmVoicePipeline() {
+  const now = Date.now();
+  if (now - lastPrewarmAt < PREWARM_INTERVAL_MS) return;
+  lastPrewarmAt = now;
+  const t0 = Date.now();
+
+  // OpenAI: key read + one tiny authed GET (models endpoint responds fast and
+  // exercises the same host as embeddings/chat/whisper).
+  openaiService.getApiKey().then(key => {
+    if (!key) return;
+    return fetch('https://api.openai.com/v1/models/gpt-4o', {
+      headers: { Authorization: `Bearer ${key}` },
+    });
+  }).then(() => console.log(`[PREWARM] openai ok ms=${Date.now() - t0}`)).catch(swallow);
+
+  // Supabase REST (pgvector search host). HEAD on the REST root is enough to
+  // open the pooled connection; no table access needed.
+  if (SUPABASE_URL && SUPABASE_ANON_KEY) {
+    fetch(`${SUPABASE_URL}/rest/v1/`, {
+      method: 'HEAD',
+      headers: { apikey: SUPABASE_ANON_KEY },
+    }).then(() => console.log(`[PREWARM] supabase ok ms=${Date.now() - t0}`)).catch(swallow);
+  }
+
+  // ElevenLabs: key read + smallest authed GET.
+  elevenLabsService.getApiKey().then(key => {
+    if (!key) return;
+    return fetch('https://api.elevenlabs.io/v1/user', {
+      headers: { 'xi-api-key': key },
+    });
+  }).then(() => console.log(`[PREWARM] elevenlabs ok ms=${Date.now() - t0}`)).catch(swallow);
+
+  // Azure: credentials live in SecureStore too — warm the cached read. The
+  // Speech SDK opens its own connection per synthesis, so there is no useful
+  // HTTP warm-up beyond the key cache.
+  azureTtsService.hasCredentials().catch(swallow);
+}

--- a/src/lib/voice/voiceConfig.js
+++ b/src/lib/voice/voiceConfig.js
@@ -52,7 +52,9 @@ const WS_STALL_TIMEOUT_MS = 6000;  // no audio while input pending → REST fall
 // talking, so the embedding + vector-search round trips (250–650 ms) are
 // already done when the final transcript lands.
 const VOICE_SPECULATIVE_RAG = true;
-const SPECULATIVE_STABLE_MS = 900;      // partial unchanged this long → fire
+// 600ms: measured on device — short questions stabilize <900ms before the
+// tap-stop, so the original threshold never fired. Refires are capped at 2.
+const SPECULATIVE_STABLE_MS = 600;      // partial unchanged this long → fire
 const SPECULATIVE_MIN_WORDS = 4;        // don't fire on fragments
 const SPECULATIVE_MAX_FIRES = 2;        // cap wasted embedding tokens per turn
 const SPECULATIVE_REUSE_JACCARD = 0.8;  // token overlap needed to reuse the result

--- a/src/lib/voice/voiceConfig.js
+++ b/src/lib/voice/voiceConfig.js
@@ -1,0 +1,80 @@
+// Single source of truth for voice-pipeline latency configuration.
+//
+// Plain CommonJS on purpose, mirroring rag/ragConfig.js: consumable by Metro,
+// Jest, and Node scripts without ESM interop surprises. Developer flags live
+// here; user-facing kill switches (handsFreeMode, fastVoiceMode) live in
+// SettingsContext and are ANDed with these at runtime.
+
+// ─── Streaming STT (PR 2) ─────────────────────────────────────────────────────
+const VOICE_STREAMING_STT = true; // expo-speech-recognition primary, Whisper-upload fallback
+
+// How long stop() waits for the recognizer's final result before using the
+// last interim transcript (the last partial is almost always the complete
+// utterance — waiting longer defeats the point of streaming STT).
+const STT_FINAL_TIMEOUT_MS = 700;
+
+// Hands-free endpointing: declare end-of-speech after this much silence
+// (no partial-transcript change AND volume below threshold). Deliberately
+// generous — elderly and hesitant speakers pause mid-thought.
+const HANDS_FREE_SILENCE_MS = 1200;
+// Give up waiting for the user to start talking after this long.
+const HANDS_FREE_MAX_LEAD_SILENCE_MS = 8000;
+// volumechange emits ≈ -2..10; the library documents "below 0" as inaudible.
+const HANDS_FREE_VOLUME_THRESHOLD = 0;
+const HANDS_FREE_VOLUME_INTERVAL_MS = 150;
+
+// ─── Streaming TTS (PR 3) ─────────────────────────────────────────────────────
+const VOICE_STREAMING_TTS = true; // ElevenLabs WebSocket stream-input; REST cascade fallback
+
+// eleven_flash_v2_5 ≈ 75 ms model TTFB vs ~275 ms for turbo_v2_5. Flip back to
+// 'eleven_turbo_v2_5' if flash quality on NZ health content disappoints (A/B).
+const ELEVEN_STREAM_MODEL = 'eleven_flash_v2_5';
+
+// PCM (not MP3) so the WebView can schedule chunks gaplessly without needing a
+// complete file for decodeAudioData. 22 kHz halves bridge traffic vs 44.1 kHz
+// and is full-band for a speech voice through phone speakers.
+const ELEVEN_STREAM_FORMAT = 'pcm_22050';
+const ELEVEN_STREAM_SAMPLE_RATE = 22050;
+
+// Server-side buffering thresholds (chars) before each successive generation —
+// small first value = sub-sentence first audio.
+const ELEVEN_CHUNK_SCHEDULE = [90, 120, 160, 250];
+
+// Re-bucket WS audio into ~this many ms per WebView inject (≈15 KB base64 at
+// 22.05 kHz — far below injectJavaScript practical limits, few enough calls).
+const CHUNK_BUCKET_MS = 250;
+
+const WS_OPEN_TIMEOUT_MS = 3000;   // WS connect slower than this → REST fallback
+const WS_STALL_TIMEOUT_MS = 6000;  // no audio while input pending → REST fallback
+
+// ─── Speculative RAG (PR 4) ───────────────────────────────────────────────────
+// Fire retrieval on a stabilized live-STT partial while the user is still
+// talking, so the embedding + vector-search round trips (250–650 ms) are
+// already done when the final transcript lands.
+const VOICE_SPECULATIVE_RAG = true;
+const SPECULATIVE_STABLE_MS = 900;      // partial unchanged this long → fire
+const SPECULATIVE_MIN_WORDS = 4;        // don't fire on fragments
+const SPECULATIVE_MAX_FIRES = 2;        // cap wasted embedding tokens per turn
+const SPECULATIVE_REUSE_JACCARD = 0.8;  // token overlap needed to reuse the result
+
+module.exports = {
+  VOICE_STREAMING_STT,
+  STT_FINAL_TIMEOUT_MS,
+  HANDS_FREE_SILENCE_MS,
+  HANDS_FREE_MAX_LEAD_SILENCE_MS,
+  HANDS_FREE_VOLUME_THRESHOLD,
+  HANDS_FREE_VOLUME_INTERVAL_MS,
+  VOICE_STREAMING_TTS,
+  ELEVEN_STREAM_MODEL,
+  ELEVEN_STREAM_FORMAT,
+  ELEVEN_STREAM_SAMPLE_RATE,
+  ELEVEN_CHUNK_SCHEDULE,
+  CHUNK_BUCKET_MS,
+  WS_OPEN_TIMEOUT_MS,
+  WS_STALL_TIMEOUT_MS,
+  VOICE_SPECULATIVE_RAG,
+  SPECULATIVE_STABLE_MS,
+  SPECULATIVE_MIN_WORDS,
+  SPECULATIVE_MAX_FIRES,
+  SPECULATIVE_REUSE_JACCARD,
+};


### PR DESCRIPTION
## Summary
- Streams every stage of the voice pipeline (live on-device STT partials, ElevenLabs WebSocket TTS with per-chunk viseme alignment, speculative RAG on stabilized partials, gapless PCM playback in the avatar WebView) with independent fallbacks to the previous blocking path at each stage
- Device-measured: **7.6s cold → 2.7–4.5s warm to first audio** on the Unity avatar's legacy path; STT finalization **700–1500ms → 37–181ms**
- Fixes found during device rollout: SDK-54 pin for expo-speech-recognition, AVAudioSession category/mode handoff (mic interruptions + quiet playback), audiostart gating (lost speech), per-profile provider voices (Brian/Bella/onyx), speech rate 0.78→0.9 with settings migration, guarded Unity native-module import, closer camera framing with Dynamic Island headroom (submodule)
- New settings: “Faster Voice Responses” (default on), “Hands-free Conversation” (default off)
- Full write-up: `docs/voice-latency-streaming.md`

## Test plan
- [x] 111 jest tests / 12 suites (new: sentence-splitter parity, streaming viseme accumulator, speculative reuse gate, WS stream service)
- [x] tsc + eslint clean
- [x] On-device verification (iPhone, dev build): live STT, volume, voices, framing, latency telemetry
- [ ] Streaming mode (`mode:"streaming"`) field test on a Three.js avatar
- [ ] Fallback drills (airplane mode mid-stream, invalid key, permission denied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)